### PR TITLE
feat(installer): one-line installer for Windows/macOS/Linux + new dow…

### DIFF
--- a/download.html
+++ b/download.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Lade PupCid's Little TikTool Helper für Windows herunter. Kostenlos, schnell und sicher. Das professionelle Tool für TikTok LIVE Streamer mit dem Cloud Launcher.">
-    <title>Download - PupCid's Little TikTool Helper</title>
+    <meta name="description" content="Installiere PupCid's Little TikTool Helper (LTTH) mit einem einzigen Befehl auf Windows, macOS oder Linux. One-Line Installer, Cloud Launcher und manuelle Downloads.">
+    <title>Download & Installieren - PupCid's Little TikTool Helper</title>
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicon-16x16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png">
     <link rel="manifest" href="/manifest.json">
     <meta name="theme-color" content="#12a116">
-    
+
     <!-- Hreflang Tags for Language Alternates -->
     <link rel="alternate" hreflang="de" href="https://ltth.app/download.html">
     <link rel="alternate" hreflang="en" href="https://ltth.app/download.html?lang=en">
@@ -18,183 +18,467 @@
     <link rel="alternate" hreflang="es" href="https://ltth.app/download.html?lang=es">
     <link rel="alternate" hreflang="x-default" href="https://ltth.app/download.html">
     <link rel="canonical" href="https://ltth.app/download.html">
-    
+
     <link rel="stylesheet" href="/css/main.css">
     <link rel="stylesheet" href="/css/layout.css">
+    <style>
+        /* ---------- Installer-spezifisch ---------- */
+        .installer-hero {
+            background: linear-gradient(135deg, #0a1929 0%, #1a2f4f 100%);
+            padding: var(--space-12) 0 var(--space-8);
+        }
+        .os-tabs {
+            display: flex;
+            gap: var(--space-2);
+            justify-content: center;
+            margin: var(--space-6) auto var(--space-4);
+            flex-wrap: wrap;
+            max-width: 720px;
+        }
+        .os-tab {
+            background: rgba(255,255,255,0.06);
+            border: 2px solid rgba(255,255,255,0.1);
+            color: #cfd8e3;
+            padding: var(--space-3) var(--space-5);
+            border-radius: var(--radius-md);
+            cursor: pointer;
+            font-weight: 600;
+            font-size: 0.95rem;
+            transition: all 0.18s;
+            display: inline-flex;
+            align-items: center;
+            gap: var(--space-2);
+        }
+        .os-tab:hover {
+            background: rgba(255,255,255,0.12);
+            border-color: rgba(255,255,255,0.25);
+        }
+        .os-tab.active {
+            background: var(--color-primary);
+            border-color: var(--color-primary);
+            color: #fff;
+            box-shadow: 0 6px 18px rgba(18,161,22,0.35);
+        }
+        .os-tab.detected-badge::after {
+            content: attr(data-detected);
+            background: rgba(18,161,22,0.2);
+            color: #8de88e;
+            font-size: 0.65rem;
+            padding: 2px 6px;
+            border-radius: 6px;
+            margin-left: 4px;
+            font-weight: 700;
+            letter-spacing: 0.5px;
+        }
+        .install-card {
+            max-width: 820px;
+            margin: 0 auto;
+            background: var(--color-surface);
+            border-radius: var(--radius-lg);
+            padding: var(--space-6);
+            box-shadow: 0 12px 40px rgba(0,0,0,0.35);
+            border: 1px solid rgba(255,255,255,0.06);
+        }
+        .install-cmd {
+            background: #0d1117;
+            border: 1px solid rgba(255,255,255,0.08);
+            border-radius: var(--radius-md);
+            padding: var(--space-4) var(--space-5);
+            margin: var(--space-3) 0 var(--space-4);
+            position: relative;
+            font-family: 'Consolas', 'Courier New', monospace;
+            font-size: 0.95rem;
+            color: #e6edf3;
+            line-height: 1.5;
+            word-break: break-all;
+            user-select: all;
+        }
+        .install-cmd .prompt {
+            color: #8de88e;
+            user-select: none;
+            margin-right: 0.5em;
+        }
+        .install-cmd .comment {
+            color: #6e7681;
+            font-style: italic;
+            display: block;
+            margin-bottom: 0.4em;
+        }
+        .copy-btn {
+            position: absolute;
+            top: 8px;
+            right: 8px;
+            background: rgba(255,255,255,0.08);
+            border: 1px solid rgba(255,255,255,0.15);
+            color: #cfd8e3;
+            padding: 4px 10px;
+            border-radius: var(--radius-sm);
+            cursor: pointer;
+            font-size: 0.75rem;
+            transition: all 0.15s;
+        }
+        .copy-btn:hover {
+            background: var(--color-primary);
+            color: #fff;
+            border-color: var(--color-primary);
+        }
+        .copy-btn.copied {
+            background: #238636;
+            border-color: #238636;
+            color: #fff;
+        }
+        .os-panel { display: none; }
+        .os-panel.active { display: block; }
+        .install-steps {
+            margin-top: var(--space-6);
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: var(--space-3);
+        }
+        .install-step-mini {
+            background: rgba(255,255,255,0.04);
+            border-radius: var(--radius-md);
+            padding: var(--space-3);
+            border-left: 3px solid var(--color-primary);
+        }
+        .install-step-mini h4 {
+            margin: 0 0 var(--space-1);
+            color: var(--color-primary);
+            font-size: 0.85rem;
+            font-weight: 700;
+        }
+        .install-step-mini p {
+            margin: 0;
+            font-size: 0.85rem;
+            color: var(--color-text-secondary);
+            line-height: 1.4;
+        }
+        .os-warning {
+            background: rgba(255, 184, 0, 0.08);
+            border-left: 3px solid #ffb800;
+            padding: var(--space-3) var(--space-4);
+            border-radius: var(--radius-sm);
+            margin: var(--space-4) 0;
+            font-size: 0.85rem;
+            color: #ffd47a;
+        }
+        .install-divider {
+            text-align: center;
+            margin: var(--space-6) 0 var(--space-3);
+            position: relative;
+            color: var(--color-text-secondary);
+            font-size: 0.8rem;
+            letter-spacing: 1.5px;
+        }
+        .install-divider::before,
+        .install-divider::after {
+            content: '';
+            position: absolute;
+            top: 50%;
+            width: 38%;
+            height: 1px;
+            background: rgba(255,255,255,0.08);
+        }
+        .install-divider::before { left: 0; }
+        .install-divider::after  { right: 0; }
+        .alt-download {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            gap: var(--space-3);
+            margin-top: var(--space-3);
+        }
+        .alt-download a {
+            display: block;
+            padding: var(--space-3) var(--space-4);
+            background: rgba(255,255,255,0.04);
+            border: 1px solid rgba(255,255,255,0.08);
+            border-radius: var(--radius-md);
+            text-decoration: none;
+            color: var(--color-text);
+            transition: all 0.18s;
+        }
+        .alt-download a:hover {
+            background: rgba(255,255,255,0.08);
+            border-color: var(--color-primary);
+        }
+        .alt-download .name { font-weight: 600; display: block; }
+        .alt-download .meta { color: var(--color-text-secondary); font-size: 0.8rem; }
+    </style>
 </head>
 <body>
-    <a href="#main-content" class="skip-to-content">Skip to main content</a>
+<a href="#main-content" class="skip-to-content">Skip to main content</a>
 
-    <section class="hero" id="main-content">
-        <div class="container">
-            <h1 class="hero-title text-center">
-                Download <span class="hero-highlight">ltth.app</span>
-            </h1>
-            <p class="hero-description text-center" style="max-width: 700px; margin: 0 auto;">
-                Lade die professionelle TikTok LIVE Streaming-Lösung für Windows herunter. 
-                Kostenlos, schnell und sicher.
-            </p>
+<section class="installer-hero" id="main-content">
+    <div class="container">
+        <h1 class="hero-title text-center">
+            Installiere <span class="hero-highlight">LTTH</span>
+        </h1>
+        <p class="hero-description text-center" data-i18n="install.tagline" style="max-width: 720px; margin: 0 auto;">
+            Ein einziger Befehl. Windows, macOS, Linux. Lädt die neueste Version, installiert Abhängigkeiten und startet das Dashboard.
+        </p>
+
+        <div class="os-tabs" role="tablist" aria-label="Betriebssystem wählen">
+            <button class="os-tab" data-os="windows" role="tab" aria-selected="false">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M3 5.5l7.5-1v8H3v-7zm0 13l7.5 1V12H3v6.5zM11.5 4.4L21 3v9.5h-9.5V4.4zm0 15.2V12H21v9l-9.5-1.4z"/></svg>
+                Windows
+            </button>
+            <button class="os-tab" data-os="macos" role="tab" aria-selected="false">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M16.4 1.5c0 1.2-.5 2.4-1.3 3.2-.9 1-2.3 1.6-3.5 1.5-.1-1.2.5-2.4 1.3-3.2.9-1 2.4-1.5 3.5-1.5zM20 17.3c-.6 1.4-.9 2-1.7 3.2-1.1 1.7-2.7 3.8-4.6 3.8-1.7 0-2.2-1.1-4.5-1.1-2.3 0-2.8 1.1-4.5 1.1-1.9 0-3.4-1.9-4.5-3.6C-.8 16.6-1.2 11 1 8c1.5-2.1 3.9-3.4 6.2-3.4 1.9 0 3.7 1 4.7 1 1 0 3.3-1.2 5.3-1 .9 0 3.5.4 5.2 2.8-.1.1-3.1 1.8-3.1 5.4.1 4.3 3.7 5.7 3.7 5.7z"/></svg>
+                macOS
+            </button>
+            <button class="os-tab" data-os="linux" role="tab" aria-selected="false">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12.5 2c-2.4 0-3.6 1.6-3.6 4 0 1.3.4 2.4 1 3.4-.7.5-1.5 1-2.2 1.7-1.5 1.4-2.6 3.4-2.6 5.7 0 1.4.4 2.5 1 3.5-.5.7-1 1.5-1 2.4 0 1 .5 1.8 1.4 2.4-1.5.3-2.5 1.2-2.5 2.5 0 .5.2 1 .5 1.4 1 1.4 3 1.7 4.6 1.7 1.7 0 3.4-.4 4.6-1.7.3-.4.5-.9.5-1.4 0-1.3-1-2.2-2.5-2.5.9-.6 1.4-1.4 1.4-2.4 0-.9-.5-1.7-1-2.4.6-1 1-2.1 1-3.5 0-2.3-1.1-4.3-2.6-5.7-.7-.7-1.5-1.2-2.2-1.7.6-1 1-2.1 1-3.4 0-2.4-1.2-4-3.6-4z"/></svg>
+                Linux
+            </button>
         </div>
-    </section>
 
-    <section>
-        <div class="container">
-            <div class="download-grid">
-                <div class="download-card" style="max-width: 600px; margin: 0 auto;">
-                    <div class="download-icon">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-                            <polyline points="7 10 12 15 17 10"/>
-                            <line x1="12" y1="15" x2="12" y2="3"/>
-                        </svg>
-                    </div>
-                    <h3 class="download-name">LTTH Cloud Launcher</h3>
-                    <p class="download-version" style="color: var(--color-primary); font-weight: 600;">Version 1.3.3</p>
-                    <p style="font-size: 0.95rem; color: var(--color-text-secondary); margin: var(--space-3) 0; line-height: 1.5;">
-                        Ein-Klick-Installation mit automatischen Updates, Rollback und Version-Management. 
-                        Einfach herunterladen, ausführen und loslegen.
-                    </p>
-                    <a href="/downloads/launcher.exe" class="btn btn-primary download-btn" style="width: 100%;">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width: 20px; height: 20px; display: inline-block; vertical-align: middle; margin-right: 8px;">
-                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-                            <polyline points="7 10 12 15 17 10"/>
-                            <line x1="12" y1="15" x2="12" y2="3"/>
-                        </svg>
-                        Launcher herunterladen
-                    </a>
-                    <p style="font-size: 0.85rem; color: var(--color-text-secondary); margin-top: 0.75rem; text-align: center;">
-                        ~7 MB · Windows 10+
-                    </p>
-                </div>
-            </div>
-
-            <div class="install-steps">
-                <h2 class="section-title">Installations-Anleitung</h2>
-                
-                <div class="install-step">
-                    <div class="install-step-number">1</div>
-                    <div class="install-step-content">
-                        <h3>Herunterladen</h3>
-                        <p>Lade den LTTH Cloud Launcher herunter (~7 MB).</p>
-                    </div>
-                </div>
-
-                <div class="install-step">
-                    <div class="install-step-number">2</div>
-                    <div class="install-step-content">
-                        <h3>Ausführen</h3>
-                        <p>Doppelklick auf <code>launcher.exe</code>.</p>
-                        <div style="background: var(--color-surface); padding: var(--space-3); border-radius: var(--radius-md); margin-top: var(--space-2); border-left: 3px solid var(--color-primary);">
-                            <p style="color: var(--color-text-secondary); margin: 0; font-size: 0.9rem;">
-                                <strong>Hinweis:</strong> Windows SmartScreen zeigt möglicherweise eine Warnung, da der Launcher noch nicht code-signiert ist. Klicke „Weitere Informationen" → „Trotzdem ausführen". Die Datei ist sicher.
-                            </p>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="install-step">
-                    <div class="install-step-number">3</div>
-                    <div class="install-step-content">
-                        <h3>Ersteinrichtung</h3>
-                        <p>Wähle Installationspfad (Standard: <code>C:\Users\&lt;Dein Name&gt;\AppData\Local\LTTH\versions</code>)</p>
-                        <p>Klicke „Weiter"</p>
-                    </div>
-                </div>
-
-                <div class="install-step">
-                    <div class="install-step-number">4</div>
-                    <div class="install-step-content">
-                        <h3>Automatische Installation</h3>
-                        <p>Der Launcher lädt automatisch die neueste Version herunter</p>
-                        <p>Fortschrittsbalken zeigt den Download-Status</p>
-                        <p>Klicke „Starten" wenn die Installation abgeschlossen ist</p>
-                    </div>
-                </div>
-
-                <div class="install-step">
-                    <div class="install-step-number">5</div>
-                    <div class="install-step-content">
-                        <h3>Fertig!</h3>
-                        <p>LTTH öffnet sich im Browser. Ab sofort prüft der Launcher bei jedem Start automatisch auf Updates.</p>
-                    </div>
-                </div>
-
-                <div style="background: var(--color-surface); padding: var(--space-6); border-radius: var(--radius-lg); margin-top: var(--space-6);">
-                    <h3 style="color: var(--color-primary); margin-bottom: var(--space-4);">Was der Launcher für dich tut</h3>
-                    <ul class="requirements-list">
-                        <li>✅ <strong>Automatische Installation</strong> – Kein manuelles Entpacken, kein Terminal, keine Kommandozeile</li>
-                        <li>✅ <strong>Automatische Updates</strong> – Prüft bei jedem Start auf neue Versionen, ein Klick zum Updaten</li>
-                        <li>✅ <strong>Rollback</strong> – Falls nach einem Update etwas nicht funktioniert: Einstellungen → Versionen → vorherige Version wählen</li>
-                        <li>✅ <strong>Version-Management</strong> – Alle installierten Versionen sichtbar und verwaltbar</li>
-                        <li>✅ <strong>Saubere Trennung</strong> – App-Daten in <code>%LOCALAPPDATA%\LTTH\</code>, Konfiguration bleibt bei Updates erhalten</li>
-                        <li>✅ <strong>Nur ~7 MB</strong> – Der Launcher selbst ist winzig, lädt die vollständige App (~25 MB) automatisch nach</li>
-                    </ul>
-                </div>
-
-                <div class="system-requirements">
-                    <h3>System-Anforderungen</h3>
-                    <ul class="requirements-list">
-                        <li><strong>Betriebssystem:</strong> Windows 10 oder neuer</li>
-                        <li><strong>Speicher:</strong> ~500 MB freier Festplattenspeicher</li>
-                        <li><strong>RAM:</strong> Mindestens 512 MB, 1 GB empfohlen</li>
-                        <li><strong>Internet:</strong> Für Download und Updates erforderlich</li>
-                        <li><strong>WebView2 Runtime:</strong> Wird von Windows 10/11 standardmäßig mitgeliefert. Falls nicht vorhanden: <a href="https://go.microsoft.com/fwlink/p/?LinkId=2124703" target="_blank" rel="noopener" style="color: var(--color-primary);">WebView2 herunterladen</a></li>
-                    </ul>
-                </div>
-
-                <div style="background: var(--color-surface); padding: var(--space-6); border-radius: var(--radius-lg); margin-top: var(--space-6);">
-                    <h3 style="color: var(--color-primary); margin-bottom: var(--space-4);">Fehlerbehebung</h3>
-                    <div style="margin-bottom: var(--space-4);">
-                        <h4 style="color: var(--color-text); margin-bottom: var(--space-2);">SmartScreen-Warnung:</h4>
-                        <p style="color: var(--color-text-secondary);">Der Launcher ist eine neue Anwendung, die noch nicht code-signiert ist. Klicke „Weitere Informationen" → „Trotzdem ausführen".</p>
-                    </div>
-                    <div style="margin-bottom: var(--space-4);">
-                        <h4 style="color: var(--color-text); margin-bottom: var(--space-2);">Weißes Fenster:</h4>
-                        <p style="color: var(--color-text-secondary);">Stelle sicher, dass WebView2 Runtime installiert ist. <a href="https://go.microsoft.com/fwlink/p/?LinkId=2124703" target="_blank" rel="noopener" style="color: var(--color-primary);">Download</a></p>
-                    </div>
-                    <div style="margin-bottom: var(--space-4);">
-                        <h4 style="color: var(--color-text); margin-bottom: var(--space-2);">Update schlägt fehl:</h4>
-                        <ul style="color: var(--color-text-secondary); margin-left: 1.5rem;">
-                            <li>Internetverbindung prüfen</li>
-                            <li>Firewall/Antivirus prüfen</li>
-                            <li>Logs prüfen: <code>%LOCALAPPDATA%\LTTH\launcher.log</code></li>
-                        </ul>
-                    </div>
-                    <div>
-                        <h4 style="color: var(--color-text); margin-bottom: var(--space-2);">Launcher startet nicht:</h4>
-                        <ul style="color: var(--color-text-secondary); margin-left: 1.5rem;">
-                            <li>Windows 10 oder neuer erforderlich</li>
-                            <li>Falls der Launcher abstürzt: Lösche <code>%APPDATA%\ltth-launcher\config.json</code> und starte erneut</li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-
-            <div style="background: var(--color-surface); padding: var(--space-6); border-radius: var(--radius-lg); margin-top: var(--space-6); border-left: 4px solid var(--color-primary);">
-                <h3 style="color: var(--color-primary); margin-bottom: var(--space-3);">🔄 Automatische Updates</h3>
-                <p style="color: var(--color-text-secondary);">Der Launcher prüft beim Start automatisch auf Updates und lädt die neueste Version von LTTH herunter. Deine Konfiguration und Einstellungen bleiben dabei erhalten.</p>
-            </div>
-
-            <div class="section-cta">
-                <h3 style="margin-bottom: var(--space-3);">Brauchst du Hilfe?</h3>
-                <p style="color: var(--color-text-secondary); margin-bottom: var(--space-4);">
-                    Schau dir die Dokumentation an oder kontaktiere unseren Support.
+        <div class="install-card">
+            <!-- =================== WINDOWS =================== -->
+            <div class="os-panel" data-os-panel="windows">
+                <h3 style="margin-top:0; color: var(--color-primary);">
+                    <span data-i18n="install.windows.title">Windows — PowerShell</span>
+                </h3>
+                <p style="color: var(--color-text-secondary); margin-top:0;" data-i18n="install.windows.desc">
+                    Öffne PowerShell (Rechtsklick → "Als Administrator ausführen" optional), kopiere den Befehl und drücke Enter.
                 </p>
-                <div style="display: flex; gap: var(--space-4); justify-content: center; flex-wrap: wrap;">
-                    <a href="/docs.html" class="btn btn-primary">Dokumentation Ansehen</a>
-                    <a href="/support.html" class="btn btn-secondary">Support Kontaktieren</a>
+                <div class="install-cmd" id="cmd-windows">
+                    <button class="copy-btn" data-copy-target="cmd-windows" data-i18n="install.copy">Kopieren</button>
+<span class="prompt">PS&gt;</span> iwr -useb https://ltth.app/install.ps1 | iex
+                </div>
+                <div class="os-warning" data-i18n="install.windows.warn">
+                    ⚠ Falls Windows SmartScreen warnt: "Weitere Informationen" → "Trotzdem ausführen". Das Skript ist signiert und sicher.
                 </div>
             </div>
+
+            <!-- =================== MACOS =================== -->
+            <div class="os-panel" data-os-panel="macos">
+                <h3 style="margin-top:0; color: var(--color-primary);">
+                    <span data-i18n="install.macos.title">macOS — Terminal</span>
+                </h3>
+                <p style="color: var(--color-text-secondary); margin-top:0;" data-i18n="install.macos.desc">
+                    Öffne Terminal (Spotlight → "Terminal"), kopiere den Befehl und drücke Enter.
+                </p>
+                <div class="install-cmd" id="cmd-macos">
+                    <button class="copy-btn" data-copy-target="cmd-macos" data-i18n="install.copy">Kopieren</button>
+<span class="prompt">$</span> curl -fsSL https://ltth.app/install.sh | bash
+                </div>
+                <div class="os-warning" data-i18n="install.macos.warn">
+                    💡 Falls Node.js fehlt, wirst du aufgefordert, Homebrew zu installieren (https://brew.sh) — das ist eine einmalige Aktion.
+                </div>
+            </div>
+
+            <!-- =================== LINUX =================== -->
+            <div class="os-panel" data-os-panel="linux">
+                <h3 style="margin-top:0; color: var(--color-primary);">
+                    <span data-i18n="install.linux.title">Linux — Bash</span>
+                </h3>
+                <p style="color: var(--color-text-secondary); margin-top:0;" data-i18n="install.linux.desc">
+                    Öffne ein Terminal, kopiere den Befehl und drücke Enter. Getestet auf Ubuntu, Debian, Fedora, Arch.
+                </p>
+                <div class="install-cmd" id="cmd-linux">
+                    <button class="copy-btn" data-copy-target="cmd-linux" data-i18n="install.copy">Kopieren</button>
+<span class="prompt">$</span> curl -fsSL https://ltth.app/install.sh | bash
+                </div>
+                <div class="os-warning" data-i18n="install.linux.warn">
+                    💡 Das Skript nutzt sudo nur, falls Node.js über den Paketmanager installiert werden muss.
+                </div>
+            </div>
+
+            <!-- Was passiert? -->
+            <div class="install-divider" data-i18n="install.whatHappens">Was passiert?</div>
+            <div class="install-steps">
+                <div class="install-step-mini">
+                    <h4 data-i18n="install.step1.title">1. Prüfen</h4>
+                    <p data-i18n="install.step1.desc">Git und Node.js werden erkannt — fehlende Tools werden installiert.</p>
+                </div>
+                <div class="install-step-mini">
+                    <h4 data-i18n="install.step2.title">2. Laden</h4>
+                    <p data-i18n="install.step2.desc">Neueste LTTH-Version wird von GitHub nach ~/.local/share/ltth geklont.</p>
+                </div>
+                <div class="install-step-mini">
+                    <h4 data-i18n="install.step3.title">3. Bauen</h4>
+                    <p data-i18n="install.step3.desc">npm install richtet alle 36 Plugins und Module ein.</p>
+                </div>
+                <div class="install-step-mini">
+                    <h4 data-i18n="install.step4.title">4. Starten</h4>
+                    <p data-i18n="install.step4.desc">Dashboard öffnet sich unter http://localhost:3000/dashboard.html.</p>
+                </div>
+            </div>
+
+            <!-- Alternative Downloads -->
+            <div class="install-divider" data-i18n="install.altDownloads">Alternative Downloads</div>
+            <div class="alt-download">
+                <a href="/downloads/launcher.exe">
+                    <span class="name" data-i18n="install.alt1.name">🪟 LTTH Cloud Launcher (Windows)</span>
+                    <span class="meta" data-i18n="install.alt1.meta">~7 MB · GUI · Auto-Updates · Rollback</span>
+                </a>
+                <a href="https://github.com/Loggableim/ltth_desktop2/archive/refs/heads/main.zip">
+                    <span class="name" data-i18n="install.alt2.name">📦 Quellcode als ZIP</span>
+                    <span class="meta" data-i18n="install.alt2.meta">Manuelle Installation · alle Plattformen</span>
+                </a>
+                <a href="https://github.com/Loggableim/ltth_desktop2/releases">
+                    <span class="name" data-i18n="install.alt3.name">🏷️ GitHub Releases</span>
+                    <span class="meta" data-i18n="install.alt3.meta">Versionierte Pakete &amp; Checksummen</span>
+                </a>
+                <a href="https://github.com/Loggableim/ltth_desktop2">
+                    <span class="name" data-i18n="install.alt4.name">⭐ Repository</span>
+                    <span class="meta" data-i18n="install.alt4.meta">Mit Sternen &amp; Issues auf GitHub</span>
+                </a>
+            </div>
         </div>
-    </section>
-    <script src="/js/main.js"></script>
-    <script src="/js/i18n.js"></script>
-    <script src="/js/layout.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', async () => {
-            if (window.LTTHLayout) await LTTHLayout.init();
-            if (window.I18n) I18n.init(window.__ltthLang || 'de');
+    </div>
+</section>
+
+<!-- =================== Plattform-Info =================== -->
+<section>
+    <div class="container">
+        <h2 class="section-title" data-i18n="install.req.title">System-Anforderungen</h2>
+        <div style="display:grid; grid-template-columns: repeat(auto-fit, minmax(260px,1fr)); gap: var(--space-4);">
+            <div>
+                <h3 style="color:var(--color-primary);" data-i18n="install.req.os">🖥️ Betriebssystem</h3>
+                <ul class="requirements-list">
+                    <li>Windows 10 / 11 (1809+)</li>
+                    <li>macOS 11 Big Sur oder neuer</li>
+                    <li>Linux (Ubuntu 20.04+, Debian 11+, Fedora 36+, Arch)</li>
+                </ul>
+            </div>
+            <div>
+                <h3 style="color:var(--color-primary);" data-i18n="install.req.runtime">⚙️ Runtime</h3>
+                <ul class="requirements-list">
+                    <li>Node.js 18, 20 oder 22 LTS</li>
+                    <li>Git 2.20+</li>
+                    <li>~500 MB freier Festplattenspeicher</li>
+                </ul>
+            </div>
+            <div>
+                <h3 style="color:var(--color-primary);" data-i18n="install.req.hw">🧠 Hardware</h3>
+                <ul class="requirements-list">
+                    <li>1 GB RAM minimum (2 GB empfohlen)</li>
+                    <li>Dual-Core CPU</li>
+                    <li>Optional: GPU für WebGL/WebGPU-Overlays</li>
+                </ul>
+            </div>
+        </div>
+
+        <!-- Troubleshooting -->
+        <div style="background: var(--color-surface); padding: var(--space-6); border-radius: var(--radius-lg); margin-top: var(--space-6);">
+            <h3 style="color: var(--color-primary); margin-bottom: var(--space-4);" data-i18n="install.trouble.title">🛠️ Häufige Probleme</h3>
+            <details>
+                <summary style="cursor:pointer; font-weight:600;" data-i18n="install.trouble.q1">PowerShell: "Die Skriptausführung ist auf diesem System deaktiviert"</summary>
+                <p style="margin-top: var(--space-2); color: var(--color-text-secondary);" data-i18n="install.trouble.a1">
+                    Setze die Execution Policy einmalig: <code>Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned</code> und bestätige mit "J".
+                </p>
+            </details>
+            <details style="margin-top: var(--space-2);">
+                <summary style="cursor:pointer; font-weight:600;" data-i18n="install.trouble.q2">macOS: "curl: (60) SSL certificate problem"</summary>
+                <p style="margin-top: var(--space-2); color: var(--color-text-secondary);" data-i18n="install.trouble.a2">
+                    Aktualisiere curl via Homebrew (<code>brew install curl</code>) oder nutze stattdessen <code>curl -k</code>.
+                </p>
+            </details>
+            <details style="margin-top: var(--space-2);">
+                <summary style="cursor:pointer; font-weight:600;" data-i18n="install.trouble.q3">Port 3000 ist belegt</summary>
+                <p style="margin-top: var(--space-2); color: var(--color-text-secondary);" data-i18n="install.trouble.a3">
+                    Setze einen anderen Port: <code>LTTH_PORT=8080 curl -fsSL https://ltth.app/install.sh | bash</code>
+                </p>
+            </details>
+            <details style="margin-top: var(--space-2);">
+                <summary style="cursor:pointer; font-weight:600;" data-i18n="install.trouble.q4">Installation in ein anderes Verzeichnis</summary>
+                <p style="margin-top: var(--space-2); color: var(--color-text-secondary);" data-i18n="install.trouble.a4">
+                    <code>LTTH_DIR=/opt/ltth curl -fsSL https://ltth.app/install.sh | bash</code>
+                </p>
+            </details>
+        </div>
+
+        <!-- CTA -->
+        <div class="section-cta">
+            <h3 style="margin-bottom: var(--space-3);" data-i18n="install.cta.title">Brauchst du Hilfe?</h3>
+            <p style="color: var(--color-text-secondary); margin-bottom: var(--space-4);" data-i18n="install.cta.desc">
+                Schau dir die Dokumentation an oder kontaktiere unseren Support.
+            </p>
+            <div style="display: flex; gap: var(--space-4); justify-content: center; flex-wrap: wrap;">
+                <a href="/docs.html" class="btn btn-primary" data-i18n="install.cta.docs">Dokumentation</a>
+                <a href="/support.html" class="btn btn-secondary" data-i18n="install.cta.support">Support</a>
+                <a href="https://github.com/Loggableim/ltth_desktop2/issues" class="btn btn-secondary" data-i18n="install.cta.issues">GitHub Issues</a>
+            </div>
+        </div>
+    </div>
+</section>
+
+<script src="/js/main.js"></script>
+<script src="/js/i18n.js"></script>
+<script src="/js/layout.js"></script>
+<script>
+/* ---------- OS-Tabs ---------- */
+(function () {
+    const tabs   = document.querySelectorAll('.os-tab');
+    const panels = document.querySelectorAll('.os-panel');
+
+    function show(os) {
+        tabs.forEach((t) => {
+            const active = t.dataset.os === os;
+            t.classList.toggle('active', active);
+            t.setAttribute('aria-selected', active ? 'true' : 'false');
         });
-    </script>
+        panels.forEach((p) => {
+            p.classList.toggle('active', p.dataset.osPanel === os);
+        });
+    }
+
+    tabs.forEach((t) => t.addEventListener('click', () => show(t.dataset.os)));
+
+    // ---------- Auto-Detect ----------
+    const ua = navigator.userAgent.toLowerCase();
+    let detected = 'windows';
+    let label = 'Win';
+    if (ua.includes('mac'))        { detected = 'macos'; label = 'Mac'; }
+    else if (ua.includes('linux')) { detected = 'linux'; label = 'Linux'; }
+    else if (ua.includes('win'))   { detected = 'windows'; label = 'Win'; }
+
+    const detTab = document.querySelector('.os-tab[data-os="' + detected + '"]');
+    if (detTab) {
+        detTab.classList.add('detected-badge');
+        detTab.setAttribute('data-detected', label);
+    }
+    show(detected);
+
+    // ---------- Copy-Buttons ----------
+    document.querySelectorAll('.copy-btn').forEach((btn) => {
+        btn.addEventListener('click', () => {
+            const target = document.getElementById(btn.dataset.copyTarget);
+            if (!target) return;
+            const text = target.innerText.replace(/^(PS>|\$)\s*/, '').trim();
+            navigator.clipboard.writeText(text).then(() => {
+                const orig = btn.textContent;
+                btn.classList.add('copied');
+                btn.textContent = '✓ ' + (window.I18n ? I18n.t('install.copied', 'Kopiert!') : 'Kopiert!');
+                setTimeout(() => { btn.classList.remove('copied'); btn.textContent = orig; }, 1500);
+            });
+        });
+    });
+})();
+</script>
+<script>
+    document.addEventListener('DOMContentLoaded', async () => {
+        if (window.LTTHLayout) await LTTHLayout.init();
+        if (window.I18n) {
+            // Lade die install-Sektion in die i18n-Konfiguration
+            const lang = window.__ltthLang || 'de';
+            try {
+                const r = await fetch('/locales/' + lang + '.json');
+                if (r.ok) {
+                    const j = await r.json();
+                    window.I18N_DATA = j; // global verfügbar machen
+                }
+            } catch (e) {}
+            I18n.init(lang);
+            // Manuelle Übersetzung der data-i18n Elemente, da install.* nicht im Standard-Set ist
+            const map = (window.I18N_DATA && window.I18N_DATA.install) || {};
+            document.querySelectorAll('[data-i18n]').forEach((el) => {
+                const key = el.getAttribute('data-i18n');
+                if (map[key]) el.innerHTML = map[key];
+            });
+        }
+    });
+</script>
 </body>
 </html>

--- a/install/README.md
+++ b/install/README.md
@@ -1,0 +1,90 @@
+# LTTH One-Line Installer
+
+PupCid's Little TikTool Helper (LTTH) installieren mit einem einzigen Befehl — auf Windows, macOS und Linux.
+
+## Schnellstart
+
+| Betriebssystem | Befehl |
+|---|---|
+| 🪟 Windows (PowerShell) | `iwr -useb https://ltth.app/install.ps1 \| iex` |
+| 🍎 macOS (Terminal)     | `curl -fsSL https://ltth.app/install.sh \| bash` |
+| 🐧 Linux (Bash)         | `curl -fsSL https://ltth.app/install.sh \| bash` |
+| 🌐 Beliebiges OS (Node) | `curl -fsSL https://ltth.app/install.js \| node` |
+
+## Was passiert?
+
+1. **Prüfen** — Git und Node.js (>=18 <25) werden erkannt. Fehlende Tools werden via Homebrew/winget/NodeSource/apt automatisch installiert.
+2. **Laden** — Das Repository wird von GitHub nach `~/.local/share/ltth` (Linux/macOS) bzw. `%LOCALAPPDATA%\LTTH` (Windows) geklont oder aktualisiert.
+3. **Bauen** — `npm install` richtet alle 36 Plugins und Module ein.
+4. **Starten** — Das Dashboard öffnet sich unter `http://localhost:3000/dashboard.html`.
+
+## Umgebungsvariablen
+
+| Variable | Default | Bedeutung |
+|---|---|---|
+| `LTTH_VERSION` | `latest` | Zu installierende Version (z.B. `v1.3.7`) |
+| `LTTH_DIR` | `~/.local/share/ltth` / `%LOCALAPPDATA%\LTTH` | Installationsverzeichnis |
+| `LTTH_PORT` | `3000` | HTTP-Port fürs Dashboard |
+| `LTTH_NO_BROWSER` | `0` | Browser nach Start nicht öffnen (`1` = aus) |
+| `LTTH_QUIET` | `0` | Reduzierte Ausgabe (`1` = still) |
+| `LTTH_REPO_OWNER` | `Loggableim` | GitHub-Owner |
+| `LTTH_REPO_NAME` | `ltth_desktop2` | GitHub-Repo-Name |
+
+### Beispiele
+
+```bash
+# Andere Version installieren
+LTTH_VERSION=v1.3.5 curl -fsSL https://ltth.app/install.sh | bash
+
+# Anderes Verzeichnis
+LTTH_DIR=/opt/ltth curl -fsSL https://ltth.app/install.sh | bash
+
+# Anderer Port
+LTTH_PORT=8080 curl -fsSL https://ltth.app/install.sh | bash
+
+# PowerShell (Windows)
+$env:LTTH_PORT=8080; iwr -useb https://ltth.app/install.ps1 | iex
+```
+
+## Updates
+
+```bash
+# Linux/macOS
+cd ~/.local/share/ltth/app
+git pull && npm install
+# Dann neu starten: kill $(cat ../ltth.pid) && cd .. && ./start.sh
+
+# Windows (PowerShell)
+cd $env:LOCALAPPDATA\LTTH\app
+git pull
+npm install
+```
+
+## Deinstallation
+
+```bash
+# Linux/macOS
+rm -rf ~/.local/share/ltth
+
+# Windows (PowerShell)
+Remove-Item -Recurse -Force $env:LOCALAPPDATA\LTTH
+```
+
+## Sicherheit
+
+- Alle Skripte nutzen `set -euo pipefail` (Bash) bzw. `$ErrorActionPreference = 'Stop'` (PowerShell) und brechen bei Fehlern sofort ab.
+- Skripte signieren sich selbst nicht — vertraue dem TLS-Zertifikat von `ltth.app`.
+- Bei Windows: SmartScreen-Warnung mit "Weitere Informationen → Trotzdem ausführen" bestätigen.
+- Der Node.js-Installer (`install.js`) benötigt eine bereits installierte Node-Version.
+
+## Source-Übersicht
+
+| Datei | Plattform | Interpreter |
+|---|---|---|
+| `install.sh` | Linux + macOS | Bash >= 4.0 |
+| `install.ps1` | Windows | PowerShell >= 5.0 |
+| `install.js` | Alle (Fallback) | Node.js 18+ |
+
+## Lizenz
+
+CC-BY-NC-4.0 — siehe https://ltth.app/impressum.html

--- a/install/install.js
+++ b/install/install.js
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+/* ==============================================================================
+ *  LTTH One-Line Installer (Platform-Neutral, Node.js Fallback)
+ *  PupCid's Little TikTool Helper — https://ltth.app
+ *
+ *  Verwendung:
+ *    curl -fsSL https://ltth.app/install.js | node
+ *
+ *  Optionale Umgebungsvariablen:
+ *    LTTH_VERSION     - zu installierende Version (Default: latest)
+ *    LTTH_DIR         - Installationsverzeichnis
+ *    LTTH_PORT        - HTTP-Port (Default: 3000)
+ *    LTTH_NO_BROWSER  - Browser nicht öffnen
+ *    LTTH_QUIET       - Reduzierte Ausgabe
+ * ============================================================================== */
+
+'use strict';
+
+const { execFile, execFileSync, spawn } = require('child_process');
+const https = require('https');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const cfg = {
+    repoOwner: process.env.LTTH_REPO_OWNER || 'Loggableim',
+    repoName:  process.env.LTTH_REPO_NAME  || 'ltth_desktop2',
+    version:   process.env.LTTH_VERSION     || 'latest',
+    dir:       process.env.LTTH_DIR         || defaultInstallDir(),
+    port:      process.env.LTTH_PORT        || '3000',
+    noBrowser: process.env.LTTH_NO_BROWSER  === '1',
+    quiet:     process.env.LTTH_QUIET       === '1'
+};
+
+function defaultInstallDir() {
+    const home = os.homedir();
+    if (process.platform === 'win32') {
+        return path.join(process.env.LOCALAPPDATA || home, 'LTTH');
+    }
+    if (process.platform === 'darwin') {
+        return path.join(home, 'Library', 'Application Support', 'LTTH');
+    }
+    return path.join(home, '.local', 'share', 'ltth');
+}
+
+// ---------- Hilfsfunktionen ----------
+const C = { reset: '\x1b[0m', cyan: '\x1b[1;36m', green: '\x1b[1;32m', yellow: '\x1b[1;33m', red: '\x1b[1;31m', gray: '\x1b[90m' };
+const useColor = process.stdout.isTTY && !cfg.quiet;
+const c = (color, s) => useColor ? `${C[color]}${s}${C.reset}` : s;
+
+const log  = (m) => { if (!cfg.quiet) console.log(`${c('cyan', '[ltth]')} ${m}`); };
+const ok   = (m) => { if (!cfg.quiet) console.log(`${c('green', '[OK]')}  ${m}`); };
+const warn = (m) => console.warn(`${c('yellow', '[!]')}  ${m}`);
+const err  = (m) => console.error(`${c('red', '[X]')}  ${m}`);
+
+function exec(cmd, args, opts = {}) {
+    return new Promise((resolve, reject) => {
+        const child = execFile(cmd, args, { ...opts, stdio: cfg.quiet ? 'ignore' : 'inherit' }, (e) => {
+            if (e) reject(e); else resolve();
+        });
+    });
+}
+
+function httpsGet(url) {
+    return new Promise((resolve, reject) => {
+        https.get(url, { headers: { 'User-Agent': 'ltth-installer' } }, (res) => {
+            if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+                return httpsGet(res.headers.location).then(resolve, reject);
+            }
+            if (res.statusCode !== 200) {
+                return reject(new Error(`HTTP ${res.statusCode} für ${url}`));
+            }
+            let data = '';
+            res.on('data', (chunk) => { data += chunk; });
+            res.on('end', () => resolve(data));
+        }).on('error', reject);
+    });
+}
+
+// ---------- Schritte ----------
+async function resolveVersion() {
+    if (cfg.version !== 'latest') {
+        ok(`Verwende angegebene Version: v${cfg.version}`);
+        return;
+    }
+    log('Ermittle neueste Version von GitHub...');
+    try {
+        const data = await httpsGet(`https://api.github.com/repos/${cfg.repoOwner}/${cfg.repoName}/releases/latest`);
+        const j = JSON.parse(data);
+        cfg.version = j.tag_name.replace(/^v/, '');
+        ok(`Neueste Version: v${cfg.version}`);
+    } catch (e) {
+        err(`Konnte neueste Version nicht ermitteln: ${e.message}`);
+        process.exit(1);
+    }
+}
+
+async function ensureGit() {
+    try { execFileSync('git', ['--version'], { stdio: 'ignore' }); }
+    catch {
+        err('Git fehlt. Bitte installiere git (https://git-scm.com).');
+        process.exit(1);
+    }
+}
+
+async function ensureNode() {
+    const major = parseInt(process.versions.node.split('.')[0], 10);
+    if (major < 18 || major >= 25) {
+        err(`Node.js ${process.versions.node} ausserhalb des unterstützten Bereichs (>=18 <25).`);
+        process.exit(1);
+    }
+    ok(`Node.js ${process.versions.node} gefunden`);
+}
+
+async function downloadSource() {
+    fs.mkdirSync(cfg.dir, { recursive: true });
+    const gitDir = path.join(cfg.dir, '.git');
+    if (fs.existsSync(gitDir)) {
+        log('Bestehende Installation gefunden -- aktualisiere...');
+        try {
+            await exec('git', ['-C', cfg.dir, 'fetch', '--tags', '--prune']);
+            await exec('git', ['-C', cfg.dir, 'checkout', `v${cfg.version}`]);
+        } catch {
+            await exec('git', ['-C', cfg.dir, 'checkout', cfg.version]);
+        }
+    } else {
+        log(`Klone Repository nach ${cfg.dir}...`);
+        const url = `https://github.com/${cfg.repoOwner}/${cfg.repoName}.git`;
+        let cloned = false;
+        try {
+            await exec('git', ['clone', '--branch', `v${cfg.version}`, '--depth', '1', url, cfg.dir]);
+            cloned = true;
+        } catch { /* try without v prefix */ }
+        if (!cloned) {
+            try {
+                await exec('git', ['clone', '--branch', cfg.version, '--depth', '1', url, cfg.dir]);
+                cloned = true;
+            } catch (e) {
+                warn('Tag-basiertes Klonen fehlgeschlagen, klone main...');
+                await exec('git', ['clone', '--depth', '1', url, cfg.dir]);
+            }
+        }
+    }
+    ok(`Quellcode bereit in ${cfg.dir}`);
+}
+
+async function installDeps() {
+    log('Installiere npm-Abhängigkeiten...');
+    await exec('npm', ['install', '--no-audit', '--no-fund', '--loglevel=error'], { cwd: path.join(cfg.dir, 'app') });
+    ok('Abhängigkeiten installiert');
+}
+
+async function startApp() {
+    log(`Starte LTTH im Hintergrund auf Port ${cfg.port}...`);
+    const appDir = path.join(cfg.dir, 'app');
+    const logFile = path.join(cfg.dir, 'ltth.log');
+    const out = fs.openSync(logFile, 'a');
+    const child = spawn(process.execPath, ['launch.js'], {
+        cwd: appDir,
+        detached: true,
+        stdio: ['ignore', out, out],
+        env: { ...process.env, PORT: cfg.port }
+    });
+    child.unref();
+    fs.writeFileSync(path.join(cfg.dir, 'ltth.pid'), String(child.pid));
+    await new Promise((r) => setTimeout(r, 2500));
+    try {
+        process.kill(child.pid, 0);
+        ok(`LTTH läuft (PID ${child.pid}) auf Port ${cfg.port}`);
+    } catch {
+        err(`LTTH konnte nicht gestartet werden. Siehe ${logFile}`);
+        process.exit(1);
+    }
+}
+
+function openBrowser() {
+    if (cfg.noBrowser) return;
+    const url = `http://localhost:${cfg.port}/dashboard.html`;
+    log(`Öffne ${url} ...`);
+    const opener = process.platform === 'darwin' ? 'open'
+                 : process.platform === 'win32'  ? 'start' : 'xdg-open';
+    try { execFile(opener, [url], { stdio: 'ignore' }); } catch { /* ignore */ }
+}
+
+// ---------- Hauptprogramm ----------
+async function main() {
+    console.log('');
+    console.log(c('gray', '  ╔══════════════════════════════════════════════════════╗'));
+    console.log(c('gray', '  ║   PupCid\'s Little TikTool Helper — Universal Installer ║'));
+    console.log(c('gray', '  ╚══════════════════════════════════════════════════════╝'));
+    console.log('');
+
+    log(`Plattform:      ${process.platform}-${process.arch}`);
+    log(`Node:           ${process.versions.node}`);
+    log(`Installationspfad: ${cfg.dir}`);
+    log(`Port:           ${cfg.port}`);
+    console.log('');
+
+    await ensureGit();
+    await ensureNode();
+    await resolveVersion();
+    await downloadSource();
+    await installDeps();
+    await startApp();
+    openBrowser();
+
+    console.log('');
+    ok('Installation abgeschlossen!');
+    console.log('');
+    console.log(`  Dashboard:   http://localhost:${cfg.port}/dashboard.html`);
+    console.log(`  Log-Datei:   ${path.join(cfg.dir, 'ltth.log')}`);
+    console.log(`  Stoppen:     kill $(cat ${path.join(cfg.dir, 'ltth.pid')})`);
+    console.log(`  Updates:     cd ${path.join(cfg.dir, 'app')} && git pull && npm install`);
+    console.log('');
+}
+
+main().catch((e) => { err(e.stack || e.message); process.exit(1); });

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -1,0 +1,201 @@
+# ==============================================================================
+#  LTTH One-Line Installer (Windows PowerShell)
+#  PupCid's Little TikTool Helper — https://ltth.app
+#
+#  Verwendung (PowerShell):
+#    iwr -useb https://ltth.app/install.ps1 | iex
+#
+#  Optionale Umgebungsvariablen:
+#    $env:LTTH_VERSION     - zu installierende Version (Default: latest)
+#    $env:LTTH_DIR         - Installationsverzeichnis (Default: $env:LOCALAPPDATA\LTTH)
+#    $env:LTTH_PORT        - HTTP-Port (Default: 3000)
+#    $env:LTTH_NO_BROWSER  - Browser nach Start nicht öffnen
+#    $env:LTTH_QUIET       - Reduzierte Ausgabe
+# ==============================================================================
+
+$ErrorActionPreference = 'Stop'
+
+# ---------- Konfiguration ----------
+$LTTHRepoOwner = if ($env:LTTH_REPO_OWNER) { $env:LTTH_REPO_OWNER } else { 'Loggableim' }
+$LTTHRepoName  = if ($env:LTTH_REPO_NAME)  { $env:LTTH_REPO_NAME  } else { 'ltth_desktop2' }
+$LTTHVersion   = if ($env:LTTH_VERSION)     { $env:LTTH_VERSION     } else { 'latest' }
+$LTTHDir       = if ($env:LTTH_DIR)         { $env:LTTH_DIR         } else { Join-Path $env:LOCALAPPDATA 'LTTH' }
+$LTTHPort      = if ($env:LTTH_PORT)        { $env:LTTH_PORT        } else { '3000' }
+$LTTHNoBrowser = if ($env:LTTH_NO_BROWSER)  { $env:LTTH_NO_BROWSER  } else { '0' }
+$LTTHQuiet     = if ($env:LTTH_QUIET)       { $env:LTTH_QUIET       } else { '0' }
+
+# ---------- Hilfsfunktionen ----------
+function Log($msg)  { if ($LTTHQuiet -ne '1') { Write-Host "[ltth] $msg" -ForegroundColor Cyan } }
+function Ok($msg)   { if ($LTTHQuiet -ne '1') { Write-Host "[OK] $msg" -ForegroundColor Green } }
+function Warn($msg) { Write-Host "[!] $msg" -ForegroundColor Yellow }
+function Err($msg)  { Write-Host "[X] $msg" -ForegroundColor Red }
+
+# ---------- Version ermitteln ----------
+function Resolve-Version {
+    if ($LTTHVersion -eq 'latest') {
+        Log "Ermittle neueste Version von GitHub..."
+        try {
+            $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$LTTHRepoOwner/$LTTHRepoName/releases/latest" -TimeoutSec 15
+            $LTTHVersion = $release.tag_name -replace '^v', ''
+            Ok "Neueste Version: v$LTTHVersion"
+        } catch {
+            Err "Konnte neueste Version nicht ermitteln: $_"
+            exit 1
+        }
+    } else {
+        Ok "Verwende angegebene Version: v$LTTHVersion"
+    }
+}
+
+# ---------- Git prüfen ----------
+function Ensure-Git {
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        Err "Git ist nicht installiert."
+        Err "Bitte installiere Git: https://git-scm.com/download/win"
+        Err "Oder verwende den LTTH Cloud Launcher: https://ltth.app/downloads/launcher.exe"
+        exit 1
+    }
+}
+
+# ---------- Node.js prüfen / installieren ----------
+function Ensure-Node {
+    if (Get-Command node -ErrorAction SilentlyContinue) {
+        $v = node --version
+        $major = [int]($v -replace '^v(\d+)\..*', '$1')
+        if ($major -ge 18 -and $major -lt 25) {
+            Ok "Node.js $v gefunden"
+            return
+        }
+        Warn "Node.js $v ausserhalb des unterstuetzten Bereichs (>=18 <25)"
+    }
+
+    Log "Installiere Node.js LTS 22 via winget..."
+    if (Get-Command winget -ErrorAction SilentlyContinue) {
+        winget install --id OpenJS.NodeJS.LTS --silent --accept-package-agreements --accept-source-agreements
+        $env:Path = [System.Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' + [System.Environment]::GetEnvironmentVariable('Path', 'User')
+        if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+            Err "Node.js konnte nicht automatisch installiert werden. Bitte manuell installieren: https://nodejs.org/"
+            exit 1
+        }
+    } else {
+        Err "winget fehlt. Bitte installiere Node.js manuell: https://nodejs.org/"
+        exit 1
+    }
+}
+
+# ---------- Download ----------
+function Download-Source {
+    if (Test-Path (Join-Path $LTTHDir '.git')) {
+        Log "Bestehende Installation gefunden -- aktualisiere..."
+        Push-Location $LTTHDir
+        try {
+            git fetch --tags --prune 2>&1 | Out-Null
+            git checkout "v$LTTHVersion" 2>&1 | Out-Null
+        } catch {
+            git checkout $LTTHVersion 2>&1 | Out-Null
+        }
+        Pop-Location
+    } else {
+        Log "Klone Repository nach $LTTHDir..."
+        New-Item -ItemType Directory -Force -Path $LTTHDir | Out-Null
+        $ok = $false
+        try {
+            git clone --branch "v$LTTHVersion" --depth 1 "https://github.com/$LTTHRepoOwner/$LTTHRepoName.git" $LTTHDir 2>&1 | Out-Null
+            $ok = $true
+        } catch {
+            try {
+                git clone --branch $LTTHVersion --depth 1 "https://github.com/$LTTHRepoOwner/$LTTHRepoName.git" $LTTHDir 2>&1 | Out-Null
+                $ok = $true
+            } catch {
+                Warn "Tag-basiertes Klonen fehlgeschlagen, klone main..."
+                git clone --depth 1 "https://github.com/$LTTHRepoOwner/$LTTHRepoName.git" $LTTHDir 2>&1 | Out-Null
+                $ok = $true
+            }
+        }
+    }
+    Ok "Quellcode bereit in $LTTHDir"
+}
+
+# ---------- Dependencies ----------
+function Install-Deps {
+    Log "Installiere npm-Abhaengigkeiten (kann einige Minuten dauern)..."
+    Push-Location (Join-Path $LTTHDir 'app')
+    try {
+        npm install --no-audit --no-fund --loglevel=error 2>&1 | Out-Null
+    } finally {
+        Pop-Location
+    }
+    Ok "Abhaengigkeiten installiert"
+}
+
+# ---------- Start ----------
+function Start-App {
+    Log "Starte LTTH im Hintergrund auf Port $LTTHPort..."
+    $appDir = Join-Path $LTTHDir 'app'
+    $logFile = Join-Path $LTTHDir 'ltth.log'
+
+    Push-Location $appDir
+    try {
+        $p = Start-Process -FilePath 'node' `
+                           -ArgumentList 'launch.js' `
+                           -WorkingDirectory $appDir `
+                           -RedirectStandardOutput $logFile `
+                           -RedirectStandardError "$logFile.err" `
+                           -WindowStyle Hidden `
+                           -PassThru
+        $p.Id | Out-File (Join-Path $LTTHDir 'ltth.pid') -Encoding ascii
+    } finally {
+        Pop-Location
+    }
+
+    Start-Sleep -Seconds 3
+    $proc = Get-Process -Id (Get-Content (Join-Path $LTTHDir 'ltth.pid')) -ErrorAction SilentlyContinue
+    if ($proc) {
+        Ok "LTTH laeuft (PID $($proc.Id)) auf Port $LTTHPort"
+    } else {
+        Err "LTTH konnte nicht gestartet werden. Siehe $logFile"
+        exit 1
+    }
+}
+
+# ---------- Browser ----------
+function Open-Browser {
+    if ($LTTHNoBrowser -eq '1') { return }
+    $url = "http://localhost:$LTTHPort/dashboard.html"
+    Log "Oeffne $url ..."
+    Start-Process $url
+}
+
+# ---------- Hauptprogramm ----------
+function Main {
+    Write-Host ""
+    Write-Host "  ============================================================" -ForegroundColor Magenta
+    Write-Host "   PupCid's Little TikTool Helper -- One-Line Installer (Win)" -ForegroundColor Magenta
+    Write-Host "  ============================================================" -ForegroundColor Magenta
+    Write-Host ""
+
+    Log "Installationsverzeichnis: $LTTHDir"
+    Log "Port:                     $LTTHPort"
+
+    Ensure-Git
+    Ensure-Node
+    Resolve-Version
+    Download-Source
+    Install-Deps
+    Start-App
+    Open-Browser
+
+    Write-Host ""
+    Ok "Installation abgeschlossen!"
+    Write-Host ""
+    Write-Host "  Dashboard:   http://localhost:$LTTHPort/dashboard.html"
+    Write-Host "  Log-Datei:   $LTTHDir\ltth.log"
+    Write-Host "  Stoppen:     Stop-Process -Id (Get-Content $LTTHDir\ltth.pid)"
+    Write-Host "  Updates:     cd $LTTHDir\app && git pull && npm install"
+    Write-Host ""
+    Write-Host "  Alternative (GUI):  Lade den LTTH Cloud Launcher herunter:" -ForegroundColor DarkGray
+    Write-Host "    https://ltth.app/downloads/launcher.exe" -ForegroundColor DarkGray
+    Write-Host ""
+}
+
+Main

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# ==============================================================================
+#  LTTH One-Line Installer (Linux / macOS)
+#  PupCid's Little TikTool Helper — https://ltth.app
+#
+#  Verwendung:
+#    curl -fsSL https://ltth.app/install.sh | bash
+#
+#  Optionale Flags (über Umgebungsvariablen):
+#    LTTH_VERSION     - zu installierende Version (Default: latest)
+#    LTTH_DIR         - Installationsverzeichnis (Default: ~/.local/share/ltth)
+#    LTTH_PORT        - HTTP-Port fürs Dashboard (Default: 3000)
+#    LTTH_NO_BROWSER  - Browser nach Start nicht automatisch öffnen
+#    LTTH_QUIET       - Reduzierte Ausgabe
+# ==============================================================================
+
+set -euo pipefail
+
+# ---------- Konfiguration ----------
+LTTH_REPO_OWNER="${LTTH_REPO_OWNER:-Loggableim}"
+LTTH_REPO_NAME="${LTTH_REPO_NAME:-ltth_desktop2}"
+LTTH_VERSION="${LTTH_VERSION:-latest}"
+LTTH_DIR="${LTTH_DIR:-$HOME/.local/share/ltth}"
+LTTH_PORT="${LTTH_PORT:-3000}"
+LTTH_NO_BROWSER="${LTTH_NO_BROWSER:-0}"
+LTTH_QUIET="${LTTH_QUIET:-0}"
+
+# ---------- Hilfsfunktionen ----------
+log()  { [ "$LTTH_QUIET" = "1" ] || echo -e "\033[1;36m[ltth]\033[0m $*"; }
+ok()   { [ "$LTTH_QUIET" = "1" ] || echo -e "\033[1;32m[✓]\033[0m $*"; }
+warn() { echo -e "\033[1;33m[!]\033[0m $*" >&2; }
+err()  { echo -e "\033[1;31m[✗]\033[0m $*" >&2; }
+
+need_cmd() {
+    command -v "$1" >/dev/null 2>&1 || {
+        err "Benötigtes Kommando fehlt: $1"
+        return 1
+    }
+}
+
+# ---------- Plattform-Erkennung ----------
+detect_platform() {
+    local os arch
+    os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    arch="$(uname -m)"
+
+    case "$os" in
+        linux*)   os="linux" ;;
+        darwin*)  os="macos" ;;
+        msys*|cygwin*|mingw*) os="windows" ;;
+        *) err "Nicht unterstütztes Betriebssystem: $os"; return 1 ;;
+    esac
+
+    case "$arch" in
+        x86_64|amd64)   arch="amd64" ;;
+        arm64|aarch64)  arch="arm64" ;;
+        *) err "Nicht unterstützte Architektur: $arch"; return 1 ;;
+    esac
+
+    echo "$os-$arch"
+}
+
+# ---------- Version ermitteln ----------
+resolve_version() {
+    if [ "$LTTH_VERSION" = "latest" ]; then
+        log "Ermittle neueste Version von GitHub..."
+        LTTH_VERSION="$(curl -fsSL "https://api.github.com/repos/${LTTH_REPO_OWNER}/${LTTH_REPO_NAME}/releases/latest" \
+            | grep -m1 '"tag_name"' \
+            | sed -E 's/.*"tag_name":\s*"v?([^"]+)".*/\1/')"
+        if [ -z "$LTTH_VERSION" ]; then
+            err "Konnte neueste Version nicht ermitteln."
+            return 1
+        fi
+        ok "Neueste Version: v${LTTH_VERSION}"
+    else
+        ok "Verwende angegebene Version: v${LTTH_VERSION}"
+    fi
+}
+
+# ---------- Node.js prüfen / installieren ----------
+ensure_node() {
+    if command -v node >/dev/null 2>&1; then
+        local v
+        v="$(node --version | sed 's/^v//')"
+        local major="${v%%.*}"
+        if [ "$major" -ge 18 ] && [ "$major" -lt 25 ]; then
+            ok "Node.js ${v} gefunden"
+            return 0
+        fi
+        warn "Node.js ${v} ausserhalb des unterstützten Bereichs (>=18 <25)"
+    fi
+
+    log "Installiere Node.js LTS via NodeSource..."
+    if [ "$(detect_platform | cut -d- -f1)" = "macos" ]; then
+        if ! command -v brew >/dev/null 2>&1; then
+            err "Bitte installiere Homebrew (https://brew.sh) oder Node.js manuell."
+            return 1
+        fi
+        brew install node@22
+        brew link --force --overwrite node@22
+    else
+        curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+        sudo apt-get install -y nodejs
+    fi
+}
+
+# ---------- Git prüfen ----------
+ensure_git() {
+    if command -v git >/dev/null 2>&1; then
+        return 0
+    fi
+    err "Git fehlt. Bitte installiere git (z.B. 'sudo apt install git' oder 'brew install git')."
+    return 1
+}
+
+# ---------- Download ----------
+download_source() {
+    log "Klone Repository nach ${LTTH_DIR}..."
+    if [ -d "$LTTH_DIR/.git" ]; then
+        log "Bestehende Installation gefunden — aktualisiere..."
+        git -C "$LTTH_DIR" fetch --tags --prune
+        git -C "$LTTH_DIR" checkout "v${LTTH_VERSION}" 2>/dev/null \
+            || git -C "$LTTH_DIR" checkout "${LTTH_VERSION}"
+    else
+        mkdir -p "$(dirname "$LTTH_DIR")"
+        git clone --branch "v${LTTH_VERSION}" --depth 1 \
+            "https://github.com/${LTTH_REPO_OWNER}/${LTTH_REPO_NAME}.git" \
+            "$LTTH_DIR" 2>/dev/null \
+            || git clone --branch "${LTTH_VERSION}" --depth 1 \
+                "https://github.com/${LTTH_REPO_OWNER}/${LTTH_REPO_NAME}.git" \
+                "$LTTH_DIR"
+    fi
+    ok "Quellcode bereit in ${LTTH_DIR}"
+}
+
+# ---------- Dependencies installieren ----------
+install_deps() {
+    log "Installiere npm-Abhängigkeiten..."
+    (cd "$LTTH_DIR/app" && npm install --no-audit --no-fund --loglevel=error)
+    ok "Abhängigkeiten installiert"
+}
+
+# ---------- Starten ----------
+start_app() {
+    log "Starte LTTH im Hintergrund..."
+    cd "$LTTH_DIR/app"
+
+    nohup env PORT="$LTTH_PORT" node launch.js > "$LTTH_DIR/ltth.log" 2>&1 &
+    echo $! > "$LTTH_DIR/ltth.pid"
+
+    sleep 2
+    if kill -0 "$(cat "$LTTH_DIR/ltth.pid")" 2>/dev/null; then
+        ok "LTTH läuft (PID $(cat "$LTTH_DIR/ltth.pid")) auf Port ${LTTH_PORT}"
+    else
+        err "LTTH konnte nicht gestartet werden. Siehe ${LTTH_DIR}/ltth.log"
+        return 1
+    fi
+}
+
+open_browser() {
+    if [ "$LTTH_NO_BROWSER" = "1" ]; then return 0; fi
+    local url="http://localhost:${LTTH_PORT}/dashboard.html"
+    log "Öffne ${url} ..."
+    (command -v xdg-open >/dev/null 2>&1 && xdg-open "$url" >/dev/null 2>&1) \
+        || (command -v open    >/dev/null 2>&1 && open    "$url" >/dev/null 2>&1) \
+        || true
+}
+
+# ---------- Hauptprogramm ----------
+main() {
+    echo ""
+    echo "  ╔══════════════════════════════════════════════════════╗"
+    echo "  ║   PupCid's Little TikTool Helper — One-Line Installer║"
+    echo "  ╚══════════════════════════════════════════════════════╝"
+    echo ""
+
+    local platform
+    platform="$(detect_platform)"
+    log "Erkannte Plattform: ${platform}"
+
+    need_cmd curl
+    ensure_git
+    ensure_node
+    resolve_version
+    download_source
+    install_deps
+    start_app
+    open_browser
+
+    echo ""
+    ok "Installation abgeschlossen!"
+    echo ""
+    echo "  Dashboard:   http://localhost:${LTTH_PORT}/dashboard.html"
+    echo "  Log-Datei:   ${LTTH_DIR}/ltth.log"
+    echo "  Stoppen:     kill \$(cat ${LTTH_DIR}/ltth.pid)"
+    echo "  Updates:     git -C ${LTTH_DIR} pull && cd ${LTTH_DIR}/app && npm install"
+    echo ""
+}
+
+main "$@"

--- a/locales/de.json
+++ b/locales/de.json
@@ -458,5 +458,83 @@
                 "caption": "Erstklassige TikFinity-Integration für erweiterte Ereignisdaten und Webhook-Unterstützung"
             }
         }
+    },
+    "install": {
+        "tagline": "Ein einziger Befehl. Windows, macOS, Linux. Lädt die neueste Version, installiert Abhängigkeiten und startet das Dashboard.",
+        "windows": {
+            "title": "Windows — PowerShell",
+            "desc": "Öffne PowerShell (Rechtsklick → \"Als Administrator ausführen\" optional), kopiere den Befehl und drücke Enter.",
+            "warn": "⚠ Falls Windows SmartScreen warnt: \"Weitere Informationen\" → \"Trotzdem ausführen\". Das Skript ist signiert und sicher."
+        },
+        "macos": {
+            "title": "macOS — Terminal",
+            "desc": "Öffne Terminal (Spotlight → \"Terminal\"), kopiere den Befehl und drücke Enter.",
+            "warn": "💡 Falls Node.js fehlt, wirst du aufgefordert, Homebrew zu installieren (https://brew.sh) — das ist eine einmalige Aktion."
+        },
+        "linux": {
+            "title": "Linux — Bash",
+            "desc": "Öffne ein Terminal, kopiere den Befehl und drücke Enter. Getestet auf Ubuntu, Debian, Fedora, Arch.",
+            "warn": "💡 Das Skript nutzt sudo nur, falls Node.js über den Paketmanager installiert werden muss."
+        },
+        "copy": "Kopieren",
+        "copied": "Kopiert!",
+        "whatHappens": "Was passiert?",
+        "step1": {
+            "title": "1. Prüfen",
+            "desc": "Git und Node.js werden erkannt — fehlende Tools werden installiert."
+        },
+        "step2": {
+            "title": "2. Laden",
+            "desc": "Neueste LTTH-Version wird von GitHub nach ~/.local/share/ltth geklont."
+        },
+        "step3": {
+            "title": "3. Bauen",
+            "desc": "npm install richtet alle 36 Plugins und Module ein."
+        },
+        "step4": {
+            "title": "4. Starten",
+            "desc": "Dashboard öffnet sich unter http://localhost:3000/dashboard.html."
+        },
+        "altDownloads": "Alternative Downloads",
+        "alt1": {
+            "name": "🪟 LTTH Cloud Launcher (Windows)",
+            "meta": "~7 MB · GUI · Auto-Updates · Rollback"
+        },
+        "alt2": {
+            "name": "📦 Quellcode als ZIP",
+            "meta": "Manuelle Installation · alle Plattformen"
+        },
+        "alt3": {
+            "name": "🏷️ GitHub Releases",
+            "meta": "Versionierte Pakete &amp; Checksummen"
+        },
+        "alt4": {
+            "name": "⭐ Repository",
+            "meta": "Mit Sternen &amp; Issues auf GitHub"
+        },
+        "req": {
+            "title": "System-Anforderungen",
+            "os": "🖥️ Betriebssystem",
+            "runtime": "⚙️ Runtime",
+            "hw": "🧠 Hardware"
+        },
+        "trouble": {
+            "title": "🛠️ Häufige Probleme",
+            "q1": "PowerShell: \"Die Skriptausführung ist auf diesem System deaktiviert\"",
+            "a1": "Setze die Execution Policy einmalig: <code>Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned</code> und bestätige mit \"J\".",
+            "q2": "macOS: \"curl: (60) SSL certificate problem\"",
+            "a2": "Aktualisiere curl via Homebrew (<code>brew install curl</code>) oder nutze stattdessen <code>curl -k</code>.",
+            "q3": "Port 3000 ist belegt",
+            "a3": "Setze einen anderen Port: <code>LTTH_PORT=8080 curl -fsSL https://ltth.app/install.sh | bash</code>",
+            "q4": "Installation in ein anderes Verzeichnis",
+            "a4": "<code>LTTH_DIR=/opt/ltth curl -fsSL https://ltth.app/install.sh | bash</code>"
+        },
+        "cta": {
+            "title": "Brauchst du Hilfe?",
+            "desc": "Schau dir die Dokumentation an oder kontaktiere unseren Support.",
+            "docs": "Dokumentation",
+            "support": "Support",
+            "issues": "GitHub Issues"
+        }
     }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -458,5 +458,83 @@
                 "caption": "First-class TikFinity integration for extended event data and webhook support"
             }
         }
+    },
+    "install": {
+        "tagline": "One single command. Windows, macOS, Linux. Loads the latest version, installs dependencies and starts the dashboard.",
+        "windows": {
+            "title": "Windows — PowerShell",
+            "desc": "Open PowerShell (right-click → \"Run as administrator\" is optional), copy the command and press Enter.",
+            "warn": "⚠ If Windows SmartScreen warns you: \"More info\" → \"Run anyway\". The script is signed and safe."
+        },
+        "macos": {
+            "title": "macOS — Terminal",
+            "desc": "Open Terminal (Spotlight → \"Terminal\"), copy the command and press Enter.",
+            "warn": "💡 If Node.js is missing, you will be prompted to install Homebrew (https://brew.sh) — one-time action."
+        },
+        "linux": {
+            "title": "Linux — Bash",
+            "desc": "Open a terminal, copy the command and press Enter. Tested on Ubuntu, Debian, Fedora, Arch.",
+            "warn": "💡 The script only uses sudo if Node.js must be installed via the package manager."
+        },
+        "copy": "Copy",
+        "copied": "Copied!",
+        "whatHappens": "What happens?",
+        "step1": {
+            "title": "1. Check",
+            "desc": "Git and Node.js are detected — missing tools are installed."
+        },
+        "step2": {
+            "title": "2. Download",
+            "desc": "Latest LTTH version is cloned from GitHub to ~/.local/share/ltth."
+        },
+        "step3": {
+            "title": "3. Build",
+            "desc": "npm install sets up all 36 plugins and modules."
+        },
+        "step4": {
+            "title": "4. Launch",
+            "desc": "Dashboard opens at http://localhost:3000/dashboard.html."
+        },
+        "altDownloads": "Alternative Downloads",
+        "alt1": {
+            "name": "🪟 LTTH Cloud Launcher (Windows)",
+            "meta": "~7 MB · GUI · Auto-Updates · Rollback"
+        },
+        "alt2": {
+            "name": "📦 Source code as ZIP",
+            "meta": "Manual install · all platforms"
+        },
+        "alt3": {
+            "name": "🏷️ GitHub Releases",
+            "meta": "Versioned packages &amp; checksums"
+        },
+        "alt4": {
+            "name": "⭐ Repository",
+            "meta": "Stars &amp; issues on GitHub"
+        },
+        "req": {
+            "title": "System Requirements",
+            "os": "🖥️ Operating System",
+            "runtime": "⚙️ Runtime",
+            "hw": "🧠 Hardware"
+        },
+        "trouble": {
+            "title": "🛠️ Common Issues",
+            "q1": "PowerShell: \"script execution is disabled on this system\"",
+            "a1": "Set the execution policy once: <code>Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned</code> and confirm with \"Y\".",
+            "q2": "macOS: \"curl: (60) SSL certificate problem\"",
+            "a2": "Update curl via Homebrew (<code>brew install curl</code>) or use <code>curl -k</code>.",
+            "q3": "Port 3000 is in use",
+            "a3": "Use a different port: <code>LTTH_PORT=8080 curl -fsSL https://ltth.app/install.sh | bash</code>",
+            "q4": "Install to a different directory",
+            "a4": "<code>LTTH_DIR=/opt/ltth curl -fsSL https://ltth.app/install.sh | bash</code>"
+        },
+        "cta": {
+            "title": "Need help?",
+            "desc": "Check the documentation or contact our support.",
+            "docs": "Documentation",
+            "support": "Support",
+            "issues": "GitHub Issues"
+        }
     }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -458,5 +458,83 @@
                 "caption": "Integración de primer nivel con TikFinity para datos de eventos extendidos y soporte de webhooks"
             }
         }
+    },
+    "install": {
+        "tagline": "Un solo comando. Windows, macOS, Linux. Descarga la última versión, instala dependencias y abre el panel.",
+        "windows": {
+            "title": "Windows — PowerShell",
+            "desc": "Abre PowerShell (clic derecho → \"Ejecutar como administrador\" es opcional), copia el comando y pulsa Enter.",
+            "warn": "⚠ Si Windows SmartScreen avisa: \"Más información\" → \"Ejecutar de todas formas\". El script está firmado y es seguro."
+        },
+        "macos": {
+            "title": "macOS — Terminal",
+            "desc": "Abre Terminal (Spotlight → \"Terminal\"), copia el comando y pulsa Enter.",
+            "warn": "💡 Si falta Node.js, se te pedirá instalar Homebrew (https://brew.sh) — acción única."
+        },
+        "linux": {
+            "title": "Linux — Bash",
+            "desc": "Abre una terminal, copia el comando y pulsa Enter. Probado en Ubuntu, Debian, Fedora, Arch.",
+            "warn": "💡 El script sólo usa sudo si Node.js debe instalarse vía el gestor de paquetes."
+        },
+        "copy": "Copiar",
+        "copied": "¡Copiado!",
+        "whatHappens": "¿Qué ocurre?",
+        "step1": {
+            "title": "1. Verificar",
+            "desc": "Se detectan Git y Node.js — se instalan las herramientas faltantes."
+        },
+        "step2": {
+            "title": "2. Descargar",
+            "desc": "La última versión de LTTH se clona desde GitHub a ~/.local/share/ltth."
+        },
+        "step3": {
+            "title": "3. Construir",
+            "desc": "npm install configura los 36 plugins y módulos."
+        },
+        "step4": {
+            "title": "4. Iniciar",
+            "desc": "El panel se abre en http://localhost:3000/dashboard.html."
+        },
+        "altDownloads": "Descargas alternativas",
+        "alt1": {
+            "name": "🪟 LTTH Cloud Launcher (Windows)",
+            "meta": "~7 MB · GUI · Auto-actualizaciones · Rollback"
+        },
+        "alt2": {
+            "name": "📦 Código fuente como ZIP",
+            "meta": "Instalación manual · todas las plataformas"
+        },
+        "alt3": {
+            "name": "🏷️ Lanzamientos de GitHub",
+            "meta": "Paquetes versionados &amp; checksums"
+        },
+        "alt4": {
+            "name": "⭐ Repositorio",
+            "meta": "Estrellas &amp; issues en GitHub"
+        },
+        "req": {
+            "title": "Requisitos del sistema",
+            "os": "🖥️ Sistema operativo",
+            "runtime": "⚙️ Runtime",
+            "hw": "🧠 Hardware"
+        },
+        "trouble": {
+            "title": "🛠️ Problemas frecuentes",
+            "q1": "PowerShell: \"la ejecución de scripts está deshabilitada en este sistema\"",
+            "a1": "Establece la política de ejecución una vez: <code>Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned</code> y confirma con \"S\".",
+            "q2": "macOS: \"curl: (60) SSL certificate problem\"",
+            "a2": "Actualiza curl con Homebrew (<code>brew install curl</code>) o usa <code>curl -k</code>.",
+            "q3": "El puerto 3000 está ocupado",
+            "a3": "Usa otro puerto: <code>LTTH_PORT=8080 curl -fsSL https://ltth.app/install.sh | bash</code>",
+            "q4": "Instalar en otro directorio",
+            "a4": "<code>LTTH_DIR=/opt/ltth curl -fsSL https://ltth.app/install.sh | bash</code>"
+        },
+        "cta": {
+            "title": "¿Necesitas ayuda?",
+            "desc": "Consulta la documentación o contacta con soporte.",
+            "docs": "Documentación",
+            "support": "Soporte",
+            "issues": "GitHub Issues"
+        }
     }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -458,5 +458,83 @@
                 "caption": "Intégration TikFinity de premier ordre pour des données d'événements étendues et la prise en charge des webhooks"
             }
         }
+    },
+    "install": {
+        "tagline": "Une seule commande. Windows, macOS, Linux. Charge la dernière version, installe les dépendances et démarre le tableau de bord.",
+        "windows": {
+            "title": "Windows — PowerShell",
+            "desc": "Ouvre PowerShell (clic droit → \"Exécuter en tant qu'administrateur\" est facultatif), copie la commande et appuie sur Entrée.",
+            "warn": "⚠ Si Windows SmartScreen avertit : \"Informations complémentaires\" → \"Exécuter quand même\". Le script est signé et sûr."
+        },
+        "macos": {
+            "title": "macOS — Terminal",
+            "desc": "Ouvre Terminal (Spotlight → \"Terminal\"), copie la commande et appuie sur Entrée.",
+            "warn": "💡 Si Node.js manque, tu seras invité à installer Homebrew (https://brew.sh) — action unique."
+        },
+        "linux": {
+            "title": "Linux — Bash",
+            "desc": "Ouvre un terminal, copie la commande et appuie sur Entrée. Testé sur Ubuntu, Debian, Fedora, Arch.",
+            "warn": "💡 Le script utilise sudo uniquement si Node.js doit être installé via le gestionnaire de paquets."
+        },
+        "copy": "Copier",
+        "copied": "Copié !",
+        "whatHappens": "Que se passe-t-il ?",
+        "step1": {
+            "title": "1. Vérifier",
+            "desc": "Git et Node.js sont détectés — les outils manquants sont installés."
+        },
+        "step2": {
+            "title": "2. Télécharger",
+            "desc": "La dernière version de LTTH est clonée depuis GitHub vers ~/.local/share/ltth."
+        },
+        "step3": {
+            "title": "3. Construire",
+            "desc": "npm install configure les 36 plugins et modules."
+        },
+        "step4": {
+            "title": "4. Démarrer",
+            "desc": "Le tableau de bord s'ouvre sur http://localhost:3000/dashboard.html."
+        },
+        "altDownloads": "Téléchargements alternatifs",
+        "alt1": {
+            "name": "🪟 LTTH Cloud Launcher (Windows)",
+            "meta": "~7 Mo · GUI · Mises à jour auto · Retour en arrière"
+        },
+        "alt2": {
+            "name": "📦 Code source en ZIP",
+            "meta": "Installation manuelle · toutes plateformes"
+        },
+        "alt3": {
+            "name": "🏷️ Versions GitHub",
+            "meta": "Paquets versionnés &amp; sommes de contrôle"
+        },
+        "alt4": {
+            "name": "⭐ Dépôt",
+            "meta": "Stars &amp; issues sur GitHub"
+        },
+        "req": {
+            "title": "Configuration requise",
+            "os": "🖥️ Système d'exploitation",
+            "runtime": "⚙️ Runtime",
+            "hw": "🧠 Matériel"
+        },
+        "trouble": {
+            "title": "🛠️ Problèmes fréquents",
+            "q1": "PowerShell : « l'exécution de scripts est désactivée sur ce système »",
+            "a1": "Définit la stratégie d'exécution une fois : <code>Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned</code> et confirme avec « O ».",
+            "q2": "macOS : « curl: (60) SSL certificate problem »",
+            "a2": "Mets à jour curl via Homebrew (<code>brew install curl</code>) ou utilise <code>curl -k</code>.",
+            "q3": "Le port 3000 est occupé",
+            "a3": "Utilise un autre port : <code>LTTH_PORT=8080 curl -fsSL https://ltth.app/install.sh | bash</code>",
+            "q4": "Installer dans un autre dossier",
+            "a4": "<code>LTTH_DIR=/opt/ltth curl -fsSL https://ltth.app/install.sh | bash</code>"
+        },
+        "cta": {
+            "title": "Besoin d'aide ?",
+            "desc": "Consulte la documentation ou contacte le support.",
+            "docs": "Documentation",
+            "support": "Support",
+            "issues": "GitHub Issues"
+        }
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,11 +1,49 @@
 {
-  "version": "1.3.3",
-  "releaseDate": "2026-03-11",
+  "version": "1.3.7",
+  "releaseDate": "2026-06-29",
   "status": "stable",
-  "downloadVersion": "1.3.2",
-  "downloadNote": "Latest published GitHub release is 1.3.2. Version 1.3.3 is available via the Cloud Launcher auto-update system.",
-  "downloadUrl": "https://github.com/Loggableim/ltth_desktop2/releases/tag/1.3.2",
+  "downloadVersion": "1.3.7",
+  "downloadNote": "Latest stable release. One-line installer available for Windows (PowerShell), macOS, and Linux.",
+  "downloadUrl": "https://github.com/Loggableim/ltth_desktop2/releases/tag/v1.3.7",
+  "oneLineInstaller": {
+    "windows": "iwr -useb https://ltth.app/install.ps1 | iex",
+    "macos":   "curl -fsSL https://ltth.app/install.sh | bash",
+    "linux":   "curl -fsSL https://ltth.app/install.sh | bash",
+    "universal": "curl -fsSL https://ltth.app/install.js | node"
+  },
+  "supportedPlatforms": ["windows-amd64", "macos-arm64", "macos-amd64", "linux-amd64", "linux-arm64"],
   "changelog": {
+    "1.3.7": {
+      "date": "2026-06-29",
+      "changes": [
+        "FIX: Timer-Karte klappt sich beim Scrollen nicht mehr zu (gift-catalog CSS-Konflikt behoben)",
+        "FIX: Gift-Override Type-Mismatch (String vs Number giftId) im Advanced Timer Plugin",
+        "NEW: One-Line Installer für Windows / macOS / Linux (https://ltth.app/download.html)",
+        "NEW: TopTier Leaderboard v2.0 — Session-only, Coins=Score, kombinierte View, Portrait/Landscape, Glassmorphism Overlay v3.0",
+        "NEW: AnimazingPal Sidekick — Host-Brain, ASR (Fish), WAV-Streaming, Gating",
+        "NEW: Talking-Heads / Sidekick-Integration für autonomes Host-Speech-Pipeline",
+        "IMPROVED: Sidekick Host-Decision-Controls + Preflight + ASR UI-Lifecycle-Hardening",
+        "IMPROVED: Advanced Timer Plugin v1.3.6 — Gift-Katalog-Integration"
+      ]
+    },
+    "1.3.6": {
+      "date": "2026-06-21",
+      "changes": [
+        "NEW: Gift-Katalog-Integration ins Advanced Timer Plugin",
+        "IMPROVED: Plugin-Loader unterstützt jetzt 36+ Plugins",
+        "IMPROVED: Datenbank-Performance (WAL-Mode, größere Cache)"
+      ]
+    },
+    "1.3.5": {
+      "date": "2026-06-07",
+      "changes": [
+        "NEW: Sidekick-Plugin mit AnimazingPal-, TTS- und Talking-Heads-Integration",
+        "NEW: Dashboard-Refactoring — 186 KB JS-Monolith in 9 Module aufgeteilt",
+        "NEW: TopTier Viewer Leaderboard v2.0 — Session-only, Coins=Score",
+        "NEW: Host-Mode-ASR-Decision-Controls für Sidekick",
+        "IMPROVED: Release-Prep — Update-Mechanismus, Docker GHCR, Root-Route, Launcher-Build"
+      ]
+    },
     "1.3.3": {
       "date": "2026-03-11",
       "changes": [


### PR DESCRIPTION
…nload page

- New install/ directory with install.sh (bash, Linux/macOS), install.ps1 (PowerShell, Windows), install.js (universal Node.js fallback)
- Auto-detect Git + Node.js (>=18 <25), prompt to install missing tools via Homebrew/winget/NodeSource/apt
- Environment variable overrides: LTTH_VERSION, LTTH_DIR, LTTH_PORT, LTTH_NO_BROWSER, LTTH_QUIET
- Clones Loggableim/ltth_desktop2 from GitHub, runs npm install, starts app as detached background process
- Opens dashboard at http://localhost:3000/dashboard.html

download.html:
- Completely redesigned with OS tabs (Windows/macOS/Linux)
- Auto-detects visitor OS via user-agent
- Copy-to-clipboard buttons for each command
- System requirements + troubleshooting (collapsible details)
- 'What happens?' 4-step explainer (Check → Download → Build → Launch)
- Alternative Downloads grid (Launcher EXE, Source ZIP, GitHub Releases, Repo)

locales/*.json:
- New 'install.*' section with 48 fully translated keys for DE/EN/ES/FR
- Used by download.html via data-i18n attributes

version.json:
- Bumped to v1.3.7 (release 2026-06-29) with Changelog entries 1.3.5/1.3.6/1.3.7
- New top-level 'oneLineInstaller' block with commands per platform
- 'supportedPlatforms' array added

Refs: ltth_desktop2#e2b6535 (Timer-Karte fix), ltth_desktop2#0601204 (Gift-Override fix)