### PR TITLE
Record canonical repository identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ This file is the first stop for future agents working on this LTTH snapshot.
 
 ## Snapshot Facts
 
+- Canonical project identity: `ltth.app`, GitHub `Loggableim/ltth.app`, website `https://ltth.app`. Read `REPOSITORY_IDENTITY.md` before using repository names or GitHub links.
 - This workspace is not a Git checkout. Do not rely on `git status`, branches, tags, or commit history until the owner uploads it to GitHub.
 - The maintained runtime is `app/`.
 - Root `package.json` is only a convenience wrapper for `app/` commands and Go launcher builds.
@@ -14,8 +15,9 @@ This file is the first stop for future agents working on this LTTH snapshot.
 
 1. Read `docs/SNAPSHOT_STATUS.md`.
 2. Read `infos/llm_start_here.md`.
-3. Inspect the relevant module or plugin before changing it.
-4. If dependencies are not installed, assume `app/node_modules` is absent and do not run Node tests until `cd app && npm install` has been done.
+3. Read `REPOSITORY_IDENTITY.md` if your task touches repository names, clone URLs, GitHub links, releases, or docs that mention old repos.
+4. Inspect the relevant module or plugin before changing it.
+5. If dependencies are not installed, assume `app/node_modules` is absent and do not run Node tests until `cd app && npm install` has been done.
 
 ## Coding Rules
 

--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -7,6 +7,7 @@ This workspace is the combined LTTH repository layout (runtime app + website + l
 ## Start Here
 
 - [README.md](README.md): project overview and commands
+- [REPOSITORY_IDENTITY.md](REPOSITORY_IDENTITY.md): canonical `ltth.app` / `Loggableim/ltth.app` identity and old-repo warning
 - [AGENTS.md](AGENTS.md): required orientation for coding agents
 - [docs/SNAPSHOT_STATUS.md](docs/SNAPSHOT_STATUS.md): current workspace facts, gaps, dependency state
 - [infos/llm_start_here.md](infos/llm_start_here.md): technical onboarding for future development
@@ -47,6 +48,7 @@ These pages may still include older wording. When a user-facing feature changes,
 - `docs_archive/` is retained only for historical context.
 - Do not treat archived implementation reports as current instructions.
 - Verify archived claims against code before using them.
+- Ignore archived references to old repositories such as `Loggableim/pupcidslittletiktoolhelper_desktop` or `mycommunity/ltth.app` unless the user explicitly asks about that history.
 
 ## Build And Runtime
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This repository contains both the LTTH runtime application and the official ltth.app website assets/docs in a single workspace snapshot.
 
+- Canonical GitHub repo: `Loggableim/ltth.app`
+- Canonical repo URL: https://github.com/Loggableim/ltth.app
+- Official website: https://ltth.app
 - Runtime app: `app/`
 - Website + marketing pages: repository root (root html/css/js/assets)
 - Launcher build sources: `build-src/`
@@ -10,6 +13,7 @@ This repository contains both the LTTH runtime application and the official ltth
 ## Current project shape
 
 - This is not a legacy Git checkout: no `.git` folder is included in this snapshot.
+- If older repo names appear in archived docs or generated reports, ignore them for current work. The active repo identity is documented in [REPOSITORY_IDENTITY.md](REPOSITORY_IDENTITY.md).
 - The root `package.json` is a convenience wrapper that delegates common commands into `app/`.
 - The old Electron main-process folder is intentionally not present in this snapshot.
 - The maintained runtime source is `app/`.
@@ -64,6 +68,7 @@ npm run lint
 - Issues: https://github.com/Loggableim/ltth.app/issues
 - App/runtime docs: [app/wiki/Getting-Started.md](app/wiki/Getting-Started.md)
 - Developer orientation:
+  - [REPOSITORY_IDENTITY.md](REPOSITORY_IDENTITY.md)
   - [AGENTS.md](AGENTS.md)
   - [infos/llm_start_here.md](infos/llm_start_here.md)
   - [docs/SNAPSHOT_STATUS.md](docs/SNAPSHOT_STATUS.md)

--- a/REPOSITORY_IDENTITY.md
+++ b/REPOSITORY_IDENTITY.md
@@ -1,0 +1,48 @@
+# Repository Identity
+
+This file is the canonical identity marker for this workspace. Read it before using repository names, clone URLs, issue links, release links, or archived implementation notes.
+
+## Canonical Project
+
+- Product/site name: `ltth.app`
+- Canonical GitHub repository: `Loggableim/ltth.app`
+- Repository URL: `https://github.com/Loggableim/ltth.app`
+- Clone URL: `https://github.com/Loggableim/ltth.app.git`
+- Default branch: `main`
+- Website: `https://ltth.app`
+
+## What This Workspace Represents
+
+This folder is the current LTTH mega-repository layout:
+
+- `app/`: maintained Node.js runtime, backend, frontend dashboard, overlays, tests, and plugins
+- repository root: public website and marketing/docs assets for `ltth.app`
+- `build-src/`: launcher and installer build sources
+- `app/wiki/`: active user documentation
+- `infos/` and `docs/`: active developer and technical documentation
+- `docs_archive/`: historical reference only
+
+The root `package.json` is a convenience wrapper. The runtime dependency manifest is `app/package.json`.
+
+## Do Not Confuse With Older Repositories
+
+Do not treat older LTTH repository names as current, even if they appear in archived notes, old implementation reports, generated docs, or stale paths.
+
+Non-canonical examples include:
+
+- `Loggableim/pupcidslittletiktoolhelper_desktop`
+- `mycommunity/ltth.app`
+- any old Electron-only desktop repository
+- any stale local path such as `ltth_desktop`, `ltth_desktop2`, or `ltth.app-main` when used as a repo identity
+
+If a document conflicts with this file, prefer this file and then verify against current code in `app/`.
+
+## Instructions For Future LLM Agents
+
+1. Use `Loggableim/ltth.app` for GitHub issues, PRs, release references, and clone instructions.
+2. Treat `https://ltth.app` as the official public website.
+3. Treat `app/` as the maintained runtime source.
+4. Treat `docs_archive/` and `new_patch/` as historical or release-context material unless a user explicitly asks about them.
+5. Do not restore Electron build assumptions unless the missing Electron source is intentionally restored.
+6. Before editing, read `AGENTS.md`, `docs/SNAPSHOT_STATUS.md`, `infos/llm_start_here.md`, and the relevant module or plugin.
+

--- a/app/plugins/osc-bridge/TROUBLESHOOTING.md
+++ b/app/plugins/osc-bridge/TROUBLESHOOTING.md
@@ -419,7 +419,7 @@ Manchmal hilft nur ein Neustart von VRChat:
 ## Weitere Hilfe
 
 ### Community
-- GitHub Issues: https://github.com/mycommunity/ltth.app/issues
+- GitHub Issues: https://github.com/Loggableim/ltth.app/issues
 - Discord: [Link zum Server]
 
 ### Logs einsenden

--- a/docs/ARCHIVE_POLICY.md
+++ b/docs/ARCHIVE_POLICY.md
@@ -7,6 +7,7 @@
 Use these first:
 
 - `README.md`
+- `REPOSITORY_IDENTITY.md`
 - `AGENTS.md`
 - `DOCUMENTATION_INDEX.md`
 - `docs/SNAPSHOT_STATUS.md`
@@ -19,6 +20,7 @@ Use these first:
 ## Archive Rules
 
 - Do not cite `docs_archive/` as current behavior without verifying the code.
+- Do not use repository names from `docs_archive/` as current identity. The active identity is `Loggableim/ltth.app` and `https://ltth.app`.
 - Do not update archive files for ordinary feature work.
 - If an archived document contains still-useful information, promote the relevant part into an active doc and leave the archive unchanged.
 - If a future cleanup deletes the archive, first confirm that no active docs link to the deleted files.
@@ -32,3 +34,4 @@ Archive files may mention:
 - Removed or renamed plugin directories.
 - GitHub workflows that no longer match this snapshot.
 - Electron/NW.js/Tauri migration experiments.
+- Old repository names such as `Loggableim/pupcidslittletiktoolhelper_desktop` or `mycommunity/ltth.app`.

--- a/docs/RELEASE_FLOW.md
+++ b/docs/RELEASE_FLOW.md
@@ -2,9 +2,11 @@
 
 This document describes the complete release workflow for PupCid's Little TikTool Helper (LTTH), including how to prepare, execute, and verify releases using the automated release system.
 
+Canonical repository identity: `Loggableim/ltth.app` at `https://github.com/Loggableim/ltth.app`. Do not use older repository names from archived reports for release work.
+
 ## Overview
 
-The LTTH release system automates the process of deploying new versions from the build repository (`ltth.app`) to the website repository (`ltth.app`), ensuring that:
+The LTTH release system automates the process of staging built LTTH payloads inside the canonical `Loggableim/ltth.app` repository, where the same repository hosts the runtime release files and the public `ltth.app` website assets. This ensures that:
 
 - The Cloud-Installer always downloads the latest version from a fixed URL
 - Old versions are properly archived
@@ -51,9 +53,9 @@ ltth.app/
 
 ## Release Process
 
-### Step 1: Prepare Build in ltth.app
+### Step 1: Prepare Build
 
-In the separate build repository (`ltth.app`):
+In the canonical `Loggableim/ltth.app` workspace:
 
 1. Complete development work for the new version
 2. Run the build process to generate the application package
@@ -77,18 +79,18 @@ IMPROVEMENTS:
 - Optimized WebSocket connection handling
 ```
 
-### Step 2: Transfer Files to ltth.app
+### Step 2: Stage Files In ltth.app
 
-In the `ltth.app` repository:
+In the `Loggableim/ltth.app` repository:
 
 1. Create a new directory in `new_patch/` with the format `ltth_X.Y.Z/`
-2. Copy the files from the build repository:
+2. Copy the prepared release files into that directory:
 
 ```bash
 # Example for version 1.2.3
 mkdir -p new_patch/ltth_1.2.3/
-cp /path/to/build/ltth_1.2.3.zip new_patch/ltth_1.2.3/
-cp /path/to/build/changelog.txt new_patch/ltth_1.2.3/
+cp /path/to/prepared-release/ltth_1.2.3.zip new_patch/ltth_1.2.3/
+cp /path/to/prepared-release/changelog.txt new_patch/ltth_1.2.3/
 ```
 
 **Expected structure:**

--- a/docs/SNAPSHOT_STATUS.md
+++ b/docs/SNAPSHOT_STATUS.md
@@ -8,6 +8,15 @@ This workspace is a local LTTH snapshot prepared for future development before p
 
 It does not contain Git metadata and currently does not contain the old Electron main-process source folder.
 
+Canonical project identity:
+
+- Product/site: `ltth.app`
+- GitHub repository: `Loggableim/ltth.app`
+- Repository URL: `https://github.com/Loggableim/ltth.app`
+- Website: `https://ltth.app`
+
+Do not confuse this snapshot with older LTTH repositories or stale archive references. `REPOSITORY_IDENTITY.md` is the canonical identity marker.
+
 ## Current Source Of Truth
 
 - Runtime app: `app/`
@@ -16,6 +25,7 @@ It does not contain Git metadata and currently does not contain the old Electron
 - Backend package: `app/package.json`
 - Root helper package: `package.json`
 - Plugin manifests: `app/plugins/*/plugin.json`
+- Repository identity: `REPOSITORY_IDENTITY.md`
 - Developer onboarding: `AGENTS.md` and `infos/llm_start_here.md`
 
 ## Dependency State
@@ -44,6 +54,7 @@ The root package has no dependency tree on purpose. It only forwards commands in
 - Electron-specific source files are missing. Any future desktop shell work needs a deliberate Electron restoration task.
 - The old root `package-lock.json` described a stale Electron package and was removed.
 - Historical docs in `docs_archive/` may mention removed paths, old plugin names, previous architecture, and obsolete release processes.
+- Historical docs may mention old repository identities such as `Loggableim/pupcidslittletiktoolhelper_desktop` or `mycommunity/ltth.app`; those are not current.
 - Some app/wiki pages may still be user-facing historical copy and should be updated feature-by-feature when touched.
 - The active Jest suite is currently test-green. Treat future failures as new regressions or environmental drift and investigate them from current output.
 

--- a/docs/thin-installer-bootstrapper.md
+++ b/docs/thin-installer-bootstrapper.md
@@ -77,7 +77,7 @@ The release workflow now produces:
 
 The Windows payload assembly logic lives in:
 
-- [build-src/scripts/package-windows-bootstrap-release.ps1](/C:/Users/logga/Documents/ltth_codex/ltth.app-main/build-src/scripts/package-windows-bootstrap-release.ps1)
+- [`build-src/scripts/package-windows-bootstrap-release.ps1`](../build-src/scripts/package-windows-bootstrap-release.ps1)
 
 Windows is the first supported bootstrapper path. The manifest and archive handling are intentionally platform-neutral so macOS/Linux payloads can be added without changing the bootstrapper contract.
 

--- a/infos/CONTRIBUTING.md
+++ b/infos/CONTRIBUTING.md
@@ -5,6 +5,7 @@ This project is currently a local snapshot. There is no Git history in the works
 ## Core Rules
 
 - Read `AGENTS.md` before work.
+- Use `Loggableim/ltth.app` as the canonical GitHub repository and `https://ltth.app` as the canonical website. See `REPOSITORY_IDENTITY.md`.
 - Treat `app/` as the runtime source of truth.
 - Keep changes scoped.
 - Do not reintroduce stale Electron assumptions unless Electron is explicitly restored.

--- a/infos/llm_start_here.md
+++ b/infos/llm_start_here.md
@@ -6,6 +6,15 @@ This is the current technical entry point for agents working on the LTTH snapsho
 
 LTTH is a local TikTok LIVE helper with a Node.js backend, Socket.IO realtime layer, SQLite persistence, static frontend assets, OBS overlays, event automation, and a plugin ecosystem.
 
+Canonical identity:
+
+- Project/site: `ltth.app`
+- GitHub repository: `Loggableim/ltth.app`
+- Repository URL: `https://github.com/Loggableim/ltth.app`
+- Website: `https://ltth.app`
+
+If older repo names appear in archive files, generated reports, comments, or paths, do not use them for current GitHub work. `REPOSITORY_IDENTITY.md` is the canonical identity marker.
+
 This workspace is a local snapshot:
 
 - No `.git` directory is present.
@@ -17,9 +26,10 @@ This workspace is a local snapshot:
 Before making changes, read:
 
 1. `AGENTS.md`
-2. `docs/SNAPSHOT_STATUS.md`
-3. this file
-4. the module or plugin you will edit
+2. `REPOSITORY_IDENTITY.md`
+3. `docs/SNAPSHOT_STATUS.md`
+4. this file
+5. the module or plugin you will edit
 
 ## Runtime Shape
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ltth.app-snapshot",
   "version": "1.3.9",
-  "description": "PupCid's Little TikTool Helper snapshot - backend app plus Windows launcher sources",
+  "description": "ltth.app snapshot for Loggableim/ltth.app - runtime app, website assets, and Windows launcher sources",
   "private": true,
   "license": "CC-BY-NC-4.0",
   "scripts": {
@@ -31,6 +31,7 @@
     "plugins"
   ],
   "notes": {
+    "repository": "Canonical GitHub repository is Loggableim/ltth.app; website is https://ltth.app. Do not use old LTTH repo names from archived docs.",
     "snapshot": "This workspace is not a Git checkout and currently does not include the Electron main-process folder. Use app/package.json for Node dependencies.",
     "install": "Run npm install in app/ before starting the backend."
   }


### PR DESCRIPTION
Commits the remaining local repository identity and documentation updates, including the canonical Loggableim/ltth.app marker.