### PR TITLE
fix(weather-control): reconnect overlay after app restart

### DIFF
--- a/app/plugins/weather-control/overlay.html
+++ b/app/plugins/weather-control/overlay.html
@@ -236,6 +236,8 @@
       let queueTimer = null;
       let debugTimer = null;
       let gamificationState = null;
+      let reconnectTimer = null;
+      let hasConnectedOnce = false;
       const resizeEngine = () => engine?.updateDimensions();
 
       function weatherText(key, fallback, params = {}) {
@@ -545,6 +547,30 @@
         }
       }
 
+      function syncOverlayConnection() {
+        if (!socket?.connected) return;
+        socket.emit('weather:client-ready');
+        socket.emit('weather:request-gamification-state');
+        broadcastState();
+      }
+
+      function scheduleServerDisconnectRecovery() {
+        if (reconnectTimer || !socket || socket.connected) return;
+        updateConnectionStatus('reconnecting', weatherText('plugins.weather-control.runtime.overlay.reconnecting_after_restart', 'Reconnecting after app restart'));
+        reconnectTimer = setTimeout(() => {
+          reconnectTimer = null;
+          if (socket && !socket.connected) socket.connect();
+        }, 1000);
+      }
+
+      function handlePluginChange(payload) {
+        const weatherWasReloaded = payload && (
+          (payload.action === 'reloaded' && payload.pluginId === 'weather-control') ||
+          payload.action === 'reloaded_all'
+        );
+        if (weatherWasReloaded) syncOverlayConnection();
+      }
+
       function initSocket() {
         socket = io({
           transports: ['websocket', 'polling'],
@@ -556,19 +582,27 @@
         });
 
         socket.on('connect', () => {
-          updateConnectionStatus('connected', weatherText('plugins.weather-control.runtime.overlay.connected', 'Connected'));
-          socket.emit('weather:client-ready');
-          socket.emit('weather:request-gamification-state');
-          broadcastState();
+          if (reconnectTimer) {
+            clearTimeout(reconnectTimer);
+            reconnectTimer = null;
+          }
+          updateConnectionStatus('connected', hasConnectedOnce
+            ? weatherText('plugins.weather-control.runtime.overlay.reconnected', 'Reconnected')
+            : weatherText('plugins.weather-control.runtime.overlay.connected', 'Connected'));
+          hasConnectedOnce = true;
+          syncOverlayConnection();
         });
 
-        socket.on('disconnect', () => updateConnectionStatus('disconnected', weatherText('plugins.weather-control.runtime.overlay.disconnected', 'Disconnected')));
+        socket.on('disconnect', (reason) => {
+          updateConnectionStatus('disconnected', weatherText('plugins.weather-control.runtime.overlay.disconnected', 'Disconnected'));
+          if (reason === 'io server disconnect') scheduleServerDisconnectRecovery();
+        });
         socket.on('reconnect_attempt', (attempt) => updateConnectionStatus('reconnecting', weatherText('plugins.weather-control.runtime.overlay.reconnecting', 'Reconnecting {attempt}', { attempt })));
         socket.on('reconnect', () => {
           updateConnectionStatus('connected', weatherText('plugins.weather-control.runtime.overlay.reconnected', 'Reconnected'));
-          socket.emit('weather:client-ready');
-          socket.emit('weather:request-gamification-state');
+          syncOverlayConnection();
         });
+        socket.on('plugins:changed', handlePluginChange);
 
         socket.on('weather:trigger', (data) => {
           totalEventsReceived++;
@@ -615,6 +649,10 @@
         if (debugTimer) clearInterval(debugTimer);
         if (stateBroadcastTimer) clearInterval(stateBroadcastTimer);
         window.removeEventListener('resize', resizeEngine);
+        if (reconnectTimer) {
+          clearTimeout(reconnectTimer);
+          reconnectTimer = null;
+        }
         if (socket) socket.disconnect();
         if (engine) engine.destroy();
         if (audioContext) audioContext.close().catch(() => {});

--- a/app/test/weather-overlay-reconnect.test.js
+++ b/app/test/weather-overlay-reconnect.test.js
@@ -1,0 +1,133 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+class FakeSocket {
+  constructor() {
+    this.connected = false;
+    this.connectCalls = 0;
+    this.emitted = [];
+    this.handlers = new Map();
+  }
+
+  on(event, handler) {
+    const handlers = this.handlers.get(event) || [];
+    handlers.push(handler);
+    this.handlers.set(event, handlers);
+    return this;
+  }
+
+  emit(event, payload) {
+    this.emitted.push({ event, payload });
+    return true;
+  }
+
+  trigger(event, ...args) {
+    for (const handler of this.handlers.get(event) || []) handler(...args);
+  }
+
+  connect() {
+    this.connectCalls += 1;
+    return this;
+  }
+
+  disconnect() {
+    return this;
+  }
+}
+
+function createOverlayDom(overlay, socket) {
+  return new JSDOM(overlay, {
+    url: 'http://localhost/weather-control/overlay',
+    runScripts: 'dangerously',
+    beforeParse(window) {
+      window.io = () => socket;
+      window.fetch = async (url) => ({
+        json: async () => url.includes('/api/weather/config')
+          ? {
+              success: true,
+              config: {
+                effects: {},
+                audio: { enabled: false, effects: {} },
+                maxConcurrentEffects: 1,
+                qualityPreset: 'high',
+                gamification: { overlay: {} }
+              }
+            }
+          : { success: true, gamification: {} }
+      });
+      window.WeatherEngine = class {
+        constructor(_canvas, options) {
+          this.options = { renderQuality: options.renderQuality };
+        }
+
+        start() {}
+        destroy() {}
+        getActiveEffects() { return []; }
+        getFPS() { return 60; }
+        getAverageFPS() { return 60; }
+        getParticleCount() { return 0; }
+        stopAllEffects() {}
+        stopEffect() {}
+      };
+    }
+  });
+}
+
+async function waitForSocketHandler(socket, event) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (socket.handlers.has(event)) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Socket handler was not registered: ${event}`);
+}
+
+describe('Weather Control overlay reconnect recovery', () => {
+  let overlay;
+
+  beforeAll(() => {
+    overlay = fs.readFileSync(
+      path.join(__dirname, '../plugins/weather-control/overlay.html'),
+      'utf8'
+    );
+  });
+
+  test('restarts the Socket.IO client after a server-initiated disconnect', () => {
+    expect(overlay).toContain("reason === 'io server disconnect'");
+    expect(overlay).toMatch(/reconnectTimer\s*=\s*setTimeout/);
+    expect(overlay).toMatch(/socket\.connect\(\)/);
+    expect(overlay).toMatch(/clearTimeout\(reconnectTimer\)/);
+  });
+
+  test('replays the ready handshake when Weather Control is reloaded', () => {
+    expect(overlay).toContain("socket.on('plugins:changed'");
+    expect(overlay).toContain("payload.pluginId === 'weather-control'");
+    expect(overlay).toContain("payload.action === 'reloaded_all'");
+    expect(overlay).toMatch(/socket\.emit\('weather:client-ready'\)/);
+  });
+
+  test('recovers a running overlay after an app restart and plugin reload', async () => {
+    const socket = new FakeSocket();
+    const dom = createOverlayDom(overlay, socket);
+
+    try {
+      await waitForSocketHandler(socket, 'disconnect');
+      socket.connected = true;
+      socket.trigger('connect');
+      const initialReadyEvents = socket.emitted.filter(({ event }) => event === 'weather:client-ready').length;
+
+      socket.connected = false;
+      socket.trigger('disconnect', 'io server disconnect');
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+      expect(socket.connectCalls).toBe(1);
+
+      socket.connected = true;
+      socket.trigger('plugins:changed', { action: 'reloaded', pluginId: 'weather-control' });
+      socket.trigger('plugins:changed', { action: 'reloaded_all' });
+      expect(socket.emitted.filter(({ event }) => event === 'weather:client-ready')).toHaveLength(initialReadyEvents + 2);
+    } finally {
+      dom.window.dispatchEvent(new dom.window.Event('beforeunload'));
+      dom.window.close();
+    }
+  });
+});

--- a/docs/superpowers/plans/2026-07-17-weather-overlay-reconnect.md
+++ b/docs/superpowers/plans/2026-07-17-weather-overlay-reconnect.md
@@ -1,0 +1,180 @@
+# Weather Control Overlay Reconnect Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (\`- [ ]\`) syntax for tracking.
+
+**Goal:** Restore the Weather Control OBS overlay automatically after an LTTH restart or a Weather Control plugin reload.
+
+**Architecture:** The overlay keeps Socket.IO's existing retry policy for normal transport failures. It adds one guarded \`socket.connect()\` recovery branch only for the server-initiated \`io server disconnect\` reason, then uses one ready-sync function for initial connections, reconnects, and the \`plugins:changed\` reload notification.
+
+**Tech Stack:** Browser JavaScript, Socket.IO client 4.x, Jest.
+
+## Global Constraints
+
+- Change only the Weather Control overlay recovery path and its focused regression test.
+- Do not reload the OBS source, restart the LTTH app, or persist any new data.
+- Preserve Socket.IO's existing infinite delayed reconnect policy for normal transport failures.
+- Use the existing Weather Control client-ready event to request permanent-effect synchronization.
+
+---
+
+### Task 1: Specify the recovery contract with a focused regression test
+
+**Files:**
+
+- Create: \`app/test/weather-overlay-reconnect.test.js\`
+- Read: \`app/plugins/weather-control/overlay.html\`
+
+**Interfaces:**
+
+- Consumes: the inline \`initSocket()\` lifecycle in \`overlay.html\`.
+- Produces: assertions for a single server-disconnect recovery timer and the reissued Weather Control ready handshake after plugin reload.
+
+- [x] **Step 1: Write the failing test**
+
+~~~js
+const fs = require('fs');
+const path = require('path');
+
+describe('Weather Control overlay reconnect recovery', () => {
+  let overlay;
+
+  beforeAll(() => {
+    overlay = fs.readFileSync(
+      path.join(__dirname, '../plugins/weather-control/overlay.html'),
+      'utf8'
+    );
+  });
+
+  test('restarts the Socket.IO client after a server-initiated disconnect', () => {
+    expect(overlay).toContain("reason === 'io server disconnect'");
+    expect(overlay).toMatch(/reconnectTimer\s*=\s*setTimeout/);
+    expect(overlay).toMatch(/socket\.connect\(\)/);
+    expect(overlay).toMatch(/clearTimeout\(reconnectTimer\)/);
+  });
+
+  test('replays the ready handshake when Weather Control is reloaded', () => {
+    expect(overlay).toContain("socket.on('plugins:changed'");
+    expect(overlay).toContain("payload.pluginId === 'weather-control'");
+    expect(overlay).toContain("payload.action === 'reloaded_all'");
+    expect(overlay).toMatch(/socket\.emit\('weather:client-ready'\)/);
+  });
+});
+~~~
+
+- [x] **Step 2: Run the test to verify it fails**
+
+Run: \`cd app && npm test -- --runInBand test/weather-overlay-reconnect.test.js\`
+
+Expected: FAIL because \`overlay.html\` has no \`io server disconnect\` branch or \`plugins:changed\` handler.
+
+### Task 2: Add guarded reconnection and ready-sync behavior
+
+**Files:**
+
+- Modify: \`app/plugins/weather-control/overlay.html:229-239\`
+- Modify: \`app/plugins/weather-control/overlay.html:532-577\`
+- Modify: \`app/plugins/weather-control/overlay.html:597-605\`
+
+**Interfaces:**
+
+- Consumes: Socket.IO client \`connect\`, \`disconnect\`, and \`plugins:changed\` events.
+- Produces: \`syncOverlayConnection()\`, \`scheduleServerDisconnectRecovery()\`, and \`handlePluginChange(payload)\` in the overlay scope.
+
+- [x] **Step 1: Add lifecycle state and the ready-sync helpers**
+
+~~~js
+let reconnectTimer = null;
+let hasConnectedOnce = false;
+
+function syncOverlayConnection() {
+  if (!socket?.connected) return;
+  socket.emit('weather:client-ready');
+  socket.emit('weather:request-gamification-state');
+  broadcastState();
+}
+
+function scheduleServerDisconnectRecovery() {
+  if (reconnectTimer || !socket || socket.connected) return;
+  updateConnectionStatus('reconnecting', 'Reconnecting after app restart');
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    if (socket && !socket.connected) socket.connect();
+  }, 1000);
+}
+
+function handlePluginChange(payload) {
+  const weatherWasReloaded =
+    (payload?.action === 'reloaded' && payload.pluginId === 'weather-control') ||
+    payload?.action === 'reloaded_all';
+  if (weatherWasReloaded) syncOverlayConnection();
+}
+~~~
+
+- [x] **Step 2: Replace duplicated connect/reconnect handlers with one \`connect\` handler**
+
+~~~js
+socket.on('connect', () => {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+  updateConnectionStatus('connected', hasConnectedOnce ? 'Reconnected' : 'Connected');
+  hasConnectedOnce = true;
+  syncOverlayConnection();
+});
+
+socket.on('disconnect', (reason) => {
+  updateConnectionStatus('disconnected', 'Disconnected');
+  if (reason === 'io server disconnect') scheduleServerDisconnectRecovery();
+});
+socket.on('plugins:changed', handlePluginChange);
+~~~
+
+Remove the old \`socket.on('reconnect', ...)\` handler so every successful connection emits exactly one ready handshake.
+
+- [x] **Step 3: Clear pending recovery during overlay cleanup**
+
+~~~js
+if (reconnectTimer) {
+  clearTimeout(reconnectTimer);
+  reconnectTimer = null;
+}
+if (socket) socket.disconnect();
+~~~
+
+- [x] **Step 4: Run the focused test to verify it passes**
+
+Run: \`cd app && npm test -- --runInBand test/weather-overlay-reconnect.test.js\`
+
+Expected: PASS with 2 tests and 0 failures.
+
+### Task 3: Verify Weather Control integration remains intact
+
+**Files:**
+
+- Test: \`app/test/weather-overlay-reconnect.test.js\`
+- Test: \`app/test/weather-control-integration.test.js\`
+
+**Interfaces:**
+
+- Consumes: the overlay source contract and existing server-side socket lifecycle test harness.
+- Produces: verification evidence for restart recovery source coverage and listener cleanup.
+
+- [x] **Step 1: Run the focused Weather Control tests**
+
+Run: \`cd app && npm test -- --runInBand test/weather-overlay-reconnect.test.js test/weather-control-integration.test.js\`
+
+Expected: PASS with 0 failures.
+
+- [x] **Step 2: Check the staged patch for whitespace errors**
+
+Run: \`git diff --check && git diff -- app/plugins/weather-control/overlay.html app/test/weather-overlay-reconnect.test.js\`
+
+Expected: no whitespace errors; diff contains only the guarded recovery, ready-sync, reload handling, and focused test.
+
+- [x] **Step 3: Commit the implementation and plan**
+
+~~~bash
+git add app/plugins/weather-control/overlay.html app/test/weather-overlay-reconnect.test.js docs/superpowers/plans/2026-07-17-weather-overlay-reconnect.md
+git commit -m "fix(weather-control): reconnect overlay after app restart"
+~~~

--- a/docs/superpowers/specs/2026-07-17-weather-overlay-reconnect-design.md
+++ b/docs/superpowers/specs/2026-07-17-weather-overlay-reconnect-design.md
@@ -1,0 +1,61 @@
+# Weather Control Overlay Reconnect Design
+
+Date: 2026-07-17
+
+## Goal
+
+Keep the Weather Control OBS browser overlay synchronized after either an LTTH
+application restart or a Weather Control plugin reload, without reloading the
+OBS source manually.
+
+## Root Cause
+
+During an LTTH restart, `app/server.js` calls `io.disconnectSockets(true)`.
+Socket.IO reports this to the browser as `io server disconnect`; unlike a
+transport failure, that reason does not start the built-in reconnect loop.
+
+During a Weather Control plugin reload, the Socket.IO connection remains open,
+but the replacement plugin instance only sees future `connection` events. The
+already connected overlay therefore does not resend `weather:client-ready` and
+is not synchronized by the replacement instance.
+
+## Design
+
+The overlay keeps Socket.IO's existing infinite, delayed reconnection policy
+for ordinary network and transport failures.
+
+For an `io server disconnect`, it schedules one explicit `socket.connect()`
+attempt. The attempt is guarded so repeated disconnect notifications cannot
+create concurrent reconnect loops. Once started, Socket.IO owns subsequent
+retry timing and backoff.
+
+The existing connect and reconnect handlers are consolidated into one overlay
+ready-sync function. It reports readiness, requests gamification state, asks
+for permanent effects, and publishes the current overlay state.
+
+The overlay also listens for the global `plugins:changed` event. When it names
+`weather-control` as reloaded, or reports a reload of all plugins, it runs the
+same ready-sync function on its still-open socket. This occurs only after the
+server has loaded the replacement plugin and emitted the event.
+
+## Error Handling
+
+- The manual reconnect branch applies only to `io server disconnect`, so normal
+  Socket.IO backoff is not bypassed or duplicated.
+- A disconnected or unavailable socket is never used for the ready sync.
+- Repeated plugin-change events are harmless: each repeats only the idempotent
+  state requests and current overlay-state publication.
+
+## Tests
+
+Add a focused regression test that proves the overlay source handles the
+server-initiated disconnect path and replays the ready handshake for both a
+socket reconnection and a Weather Control reload notification. Keep the
+existing Weather Control integration suite green to protect server-side socket
+listener cleanup and state sanitization.
+
+## Non-Goals
+
+- No change to Socket.IO server configuration or global reconnect policy.
+- No OBS source reload, app restart, or user configuration change.
+- No changes to weather-effect rendering or persisted Weather Control data.


### PR DESCRIPTION
## Summary
- recover the OBS Weather Control overlay after an LTTH server restart
- replay the Weather Control ready handshake after plugin reloads
- cover restart and reload recovery with a JSDOM regression test

## Root cause
LTTH intentionally uses a server-side Socket.IO disconnect during restart. Socket.IO does not automatically reconnect clients for that reason, and plugin reloads leave existing sockets connected without a new client-ready signal.

## Verification
- 
pm test -- --runInBand test/weather-overlay-reconnect.test.js test/weather-control-integration.test.js
- 
pm run lint -- --quiet
- inline overlay JavaScript syntax check