### PR TITLE
fix(tiktok): refresh gift catalog while offline

### DIFF
--- a/app/modules/adapters/EulerstreamAdapter.js
+++ b/app/modules/adapters/EulerstreamAdapter.js
@@ -3179,14 +3179,30 @@ class EulerstreamAdapter extends BaseAdapter {
             fetchRoomId: options.fetchRoomId
         };
         const localeCode = this._normalizeLocaleCode(options.locale_code || options.localeCode);
+        const normalizeUsername = (value) => String(value || '').replace(/^@/, '').trim();
+        const preferConnected = options.preferConnected !== false;
+        const requestedUsername = normalizeUsername(options.username);
+        const connectedUsername = preferConnected && this.isConnected
+            ? normalizeUsername(this.currentUsername)
+            : '';
+        const savedUsername = normalizeUsername(this.db.getSetting('last_connected_username'));
+        const lookupUsername = requestedUsername
+            || connectedUsername
+            || normalizeUsername(this.currentUsername)
+            || savedUsername;
 
         // Fetch gift catalog from TikTok's Webcast API.
         this._mergeSessionGiftsIntoCatalog();
 
-        // Try to get room ID if we don't have it. Gift list can still be fetched without it.
-        if (!this.roomId && requestedOptions.fetchRoomId !== false && this.currentUsername) {
+        // Refresh the room ID after disconnects as well, so catalog refreshes can
+        // use the last known account without requiring a live connection.
+        if (
+            lookupUsername
+            && requestedOptions.fetchRoomId !== false
+            && !this.roomId
+        ) {
             try {
-                await this.fetchRoomId(this.currentUsername);
+                await this.fetchRoomId(lookupUsername);
             } catch (error) {
                 this.logger.warn(`Could not fetch room ID before gift catalog refresh: ${this._formatHttpError(error)}`);
             }

--- a/app/server.js
+++ b/app/server.js
@@ -2743,7 +2743,13 @@ app.get('/api/gift-catalog', apiLimiter, (req, res) => {
 app.post('/api/gift-catalog/update', apiLimiter, async (req, res) => {
     try {
         const locale = req.query.locale || req.body?.locale || req.locale || db.getSetting('language') || 'en';
-        const result = await tiktok.updateGiftCatalog({ localeCode: locale });
+        const requestedUsername = (req.body?.username || '').toString().trim().replace(/^@/, '');
+        const fallbackUsername = db.getSetting('last_connected_username');
+        const result = await tiktok.updateGiftCatalog({
+            localeCode: locale,
+            preferConnected: true,
+            username: requestedUsername || fallbackUsername || undefined
+        });
         logger.info('🎁 Gift catalog updated');
         res.json({ success: true, ...result });
     } catch (error) {

--- a/app/test/gift-catalog-live-roomid.test.js
+++ b/app/test/gift-catalog-live-roomid.test.js
@@ -132,6 +132,37 @@ describe('Gift catalog refresh while connected', () => {
     expect(result.count).toBe(1);
   });
 
+  test('uses the saved username to refresh the room ID while disconnected', async () => {
+    const { adapter, db } = createAdapter();
+    db.getSetting.mockImplementation((key) => (
+      key === 'last_connected_username' ? '@offline-streamer' : null
+    ));
+    adapter.currentUsername = null;
+    adapter.fetchRoomId = jest.fn(async (username) => {
+      adapter.roomId = '7312345678901234569';
+      return username;
+    });
+    axios.get.mockResolvedValueOnce({
+      data: {
+        data: {
+          gifts: [{
+            id: '5655',
+            name: 'Rose',
+            image: { url_list: ['https://example.test/rose.png'] },
+            diamond_count: '1'
+          }]
+        }
+      }
+    });
+
+    const result = await adapter.updateGiftCatalog({ preferConnected: true });
+
+    expect(adapter.fetchRoomId).toHaveBeenCalledWith('offline-streamer');
+    expect(axios.get.mock.calls[0][0]).toContain('room_id=7312345678901234569');
+    expect(result.success).toBe(true);
+    expect(result.count).toBe(1);
+  });
+
   test('normalizes locale codes before persisting refreshed gift catalogs', async () => {
     const { adapter, db } = createAdapter();
 


### PR DESCRIPTION
## Änderung
Portiert den noch fehlenden Offline-Giftkatalog-Fallback aus dem Legacy-PR [Loggableim/ltth_desktop2#278](https://github.com/Loggableim/ltth_desktop2/pull/278) in das kanonische Repository.

- verwendet bei fehlender Room-ID den aktiven, angeforderten oder zuletzt gespeicherten TikTok-Benutzernamen
- reicht den Benutzer-Fallback über `POST /api/gift-catalog/update` bis zum Eulerstream-Adapter durch
- bewahrt bereits bekannte Room-IDs unverändert

## Legacy-PR #277
Die Reconnect-Absicht aus [#277](https://github.com/Loggableim/ltth_desktop2/pull/277) ist bereits in `ltth.app/main` enthalten: manueller Disconnect-Schutz, Timer-Cleanup und begrenzter Backoff-Reconnect liegen im `EulerstreamAdapter` vor.

## Prüfung
- `node --check modules/adapters/EulerstreamAdapter.js`
- `node --check server.js`
- `jest test/gift-catalog-live-roomid.test.js test/eulerstream-connection-state.test.js --runInBand` (23/23)

Der lokale Gesamtlauf lieferte innerhalb von zwei Minuten kein Ergebnis und ist nicht als erfolgreich bewertet.